### PR TITLE
PI-7: Convert Down Penalty

### DIFF
--- a/contracts/beanstalk/facets/silo/ConvertFacet.sol
+++ b/contracts/beanstalk/facets/silo/ConvertFacet.sol
@@ -126,6 +126,16 @@ contract ConvertFacet is Invariable, ReentrancyGuard {
             );
         }
 
+        if (cp.toToken != s.sys.bean && cp.fromToken == s.sys.bean) {
+            uint256 grownStalkLost;
+            (pipeData.grownStalk, grownStalkLost) = LibConvert.downPenalizedGrownStalk(
+                cp.toToken,
+                toBdv,
+                pipeData.grownStalk
+            );
+            emit LibConvert.ConvertDownPenalty(grownStalkLost);
+        }
+
         toStem = LibConvert._depositTokensForConvert(
             cp.toToken,
             cp.toAmount,

--- a/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
+++ b/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
@@ -142,4 +142,19 @@ contract ConvertGettersFacet {
                 outputToken
             );
     }
+
+    /**
+     * @notice Returns the amount of grown stalk remaining after application of down penalty.
+     * @dev Germinating deposits are not penalized.
+     * @dev Does not factor in other sources of stalk change during convert.
+     * @return newGrownStalk Amount of grown stalk to assign the output deposit.
+     * @return grownStalkLost Amount of grown stalk lost due to down penalty.
+     */
+    function downPenalizedGrownStalk(
+        address well,
+        uint256 bdvToConvert,
+        uint256 grownStalkToConvert
+    ) external view returns (uint256 newGrownStalk, uint256 grownStalkLost) {
+        return LibConvert.downPenalizedGrownStalk(well, bdvToConvert, grownStalkToConvert);
+    }
 }

--- a/contracts/beanstalk/facets/silo/PipelineConvertFacet.sol
+++ b/contracts/beanstalk/facets/silo/PipelineConvertFacet.sol
@@ -107,6 +107,16 @@ contract PipelineConvertFacet is Invariable, ReentrancyGuard {
             advancedPipeCalls
         );
 
+        if (outputToken != s.sys.bean && inputToken == s.sys.bean) {
+            uint256 grownStalkLost;
+            (grownStalk, grownStalkLost) = LibConvert.downPenalizedGrownStalk(
+                outputToken,
+                toBdv,
+                grownStalk
+            );
+            emit LibConvert.ConvertDownPenalty(grownStalkLost);
+        }
+
         toStem = LibConvert._depositTokensForConvert(
             outputToken,
             toAmount,

--- a/contracts/beanstalk/facets/sun/GaugeFacet.sol
+++ b/contracts/beanstalk/facets/sun/GaugeFacet.sol
@@ -12,6 +12,7 @@ import {C} from "contracts/C.sol";
 import {LibDiamond} from "contracts/libraries/LibDiamond.sol";
 import {LibGaugeHelpers} from "contracts/libraries/LibGaugeHelpers.sol";
 import {Gauge, GaugeId} from "contracts/beanstalk/storage/System.sol";
+import {PRBMathUD60x18} from "@prb/math/contracts/PRBMathUD60x18.sol";
 
 /**
  * @title GaugeFacet
@@ -30,6 +31,12 @@ interface IGaugeFacet {
         bytes memory systemData,
         bytes memory gaugeData
     ) external view returns (bytes memory result);
+
+    function convertDownPenaltyRatioGauge(
+        bytes memory value,
+        bytes memory,
+        bytes memory gaugeData
+    ) external view returns (bytes memory, bytes memory);
 }
 
 /**
@@ -100,6 +107,54 @@ contract GaugeFacet is GaugeDefault, ReentrancyGuard {
             ),
             gaugeData
         );
+    }
+
+    /**
+     * @notice tracks the down convert penalty ratio and the rolling count of seasons above peg.
+     * Penalty ratio is the % of grown stalk lost on a down convert (1.0 = 100% penalty).
+     * value is encoded as (uint256, uint256):
+     *     penaltyRatio - the penalty ratio.
+     *     rollingSeasonsAbovePeg - the rolling count of seasons above peg.
+     * gaugeData encoded as (uint256, uint256):
+     *     rollingSeasonsAbovePegRate - amount to change the the rolling count by each season.
+     *     rollingSeasonsAbovePegCap - upper limit of rolling count.
+     */
+    function convertDownPenaltyRatioGauge(
+        bytes memory value,
+        bytes memory systemData,
+        bytes memory gaugeData
+    ) external view returns (bytes memory, bytes memory) {
+        LibEvaluate.BeanstalkState memory bs = abi.decode(systemData, (LibEvaluate.BeanstalkState));
+        (uint256 rollingSeasonsAbovePegRate, uint256 rollingSeasonsAbovePegCap) = abi.decode(
+            gaugeData,
+            (uint256, uint256)
+        );
+
+        (, uint256 rollingSeasonsAbovePeg) = abi.decode(value, (uint256, uint256));
+        rollingSeasonsAbovePeg = uint256(
+            LibGaugeHelpers.linear(
+                int256(rollingSeasonsAbovePeg),
+                bs.twaDeltaB > 0 ? true : false,
+                rollingSeasonsAbovePegRate,
+                0,
+                int256(rollingSeasonsAbovePegCap)
+            )
+        );
+
+        uint256 timeRatio;
+        if (rollingSeasonsAbovePeg == 0) {
+            timeRatio = 0;
+        } else {
+            timeRatio =
+                (1e18 * PRBMathUD60x18.log2(rollingSeasonsAbovePeg * 1e18)) /
+                PRBMathUD60x18.log2(rollingSeasonsAbovePegCap * 1e18);
+        }
+
+        uint256 penaltyRatio = bs.lpToSupplyRatio.value -
+            (timeRatio * bs.lpToSupplyRatio.value) /
+            1e18;
+
+        return (abi.encode(penaltyRatio, rollingSeasonsAbovePeg), gaugeData);
     }
 
     /// GAUGE ADD/REMOVE/UPDATE ///

--- a/contracts/beanstalk/facets/sun/SeasonFacet.sol
+++ b/contracts/beanstalk/facets/sun/SeasonFacet.sol
@@ -110,7 +110,7 @@ contract SeasonFacet is Invariable, Weather {
 
     /**
      * @notice Steps all gauges in the system.
-     * @param bs The BeanstalkState memory struct containing data of beanstalk's current.
+     * @param bs The BeanstalkState memory struct containing data of beanstalk's current state.
      */
     function stepGauges(LibEvaluate.BeanstalkState memory bs) internal {
         bytes memory systemData = abi.encode(bs);

--- a/contracts/beanstalk/facets/sun/abstract/Sun.sol
+++ b/contracts/beanstalk/facets/sun/abstract/Sun.sol
@@ -80,7 +80,6 @@ abstract contract Sun is Oracle, Distribution {
                 priorHarvestable +
                 s.sys.rain.floodHarvestablePods;
             setSoilAbovePeg(newHarvestable, caseId);
-
             s.sys.season.abovePeg = true;
         } else {
             // Below peg

--- a/contracts/beanstalk/init/InitPI7.sol
+++ b/contracts/beanstalk/init/InitPI7.sol
@@ -1,0 +1,36 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity ^0.8.20;
+import "../../libraries/LibAppStorage.sol";
+import {Gauge, GaugeId} from "contracts/beanstalk/storage/System.sol";
+import {LibGaugeHelpers} from "../../libraries/LibGaugeHelpers.sol";
+import {IGaugeFacet} from "contracts/beanstalk/facets/sun/GaugeFacet.sol";
+
+/**
+ * @title InitPI7
+ * @dev Initializes parameters for pinto improvement 7.
+ **/
+contract InitPI7 {
+    uint256 internal constant INIT_CONVERT_DOWN_PENALTY_RATIO = 0;
+    uint256 internal constant INIT_ROLLING_SEASONS_ABOVE_PEG = 0;
+    uint256 internal constant ROLLING_SEASONS_ABOVE_PEG_CAP = 12;
+    uint256 internal constant ROLLING_SEASONS_ABOVE_PEG_RATE = 1;
+
+    function init() external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        // Update Q.
+        s.sys.evaluationParameters.excessivePriceThreshold = 1.025e6;
+
+        // Initialize and add convertDownPenaltyRatioGauge.
+        Gauge memory convertDownPenaltyRatioGauge = Gauge(
+            abi.encode(INIT_CONVERT_DOWN_PENALTY_RATIO, INIT_ROLLING_SEASONS_ABOVE_PEG),
+            address(this),
+            IGaugeFacet.convertDownPenaltyRatioGauge.selector,
+            abi.encode(ROLLING_SEASONS_ABOVE_PEG_RATE, ROLLING_SEASONS_ABOVE_PEG_CAP)
+        );
+        LibGaugeHelpers.addGauge(GaugeId.CONVERT_DOWN_PENALTY_RATIO, convertDownPenaltyRatioGauge);
+    }
+}

--- a/contracts/beanstalk/init/InitalizeDiamond.sol
+++ b/contracts/beanstalk/init/InitalizeDiamond.sol
@@ -51,7 +51,7 @@ contract InitalizeDiamond {
     uint256 internal constant LP_TO_SUPPLY_RATIO_LOWER_BOUND = 0.12e18; // 12%
 
     // Excessive price threshold constant
-    uint256 internal constant EXCESSIVE_PRICE_THRESHOLD = 1.05e6;
+    uint256 internal constant EXCESSIVE_PRICE_THRESHOLD = 1.025e6;
 
     /// @dev When the Pod Rate is high, issue less Soil.
     uint256 private constant SOIL_COEFFICIENT_HIGH = 0.25e18;
@@ -89,6 +89,16 @@ contract InitalizeDiamond {
     uint256 internal constant MAX_DELTA_CULTIVATION_FACTOR = 2e6; // 2%
     uint256 internal constant MIN_CULTIVATION_FACTOR = 1e6; // 1%
     uint256 internal constant MAX_CULTIVATION_FACTOR = 100e6; // 100%
+
+    // Rolling Seasons Above Peg.
+    // The % penalty to be applied to grown stalk when down converting.
+    uint256 internal constant INIT_CONVERT_DOWN_PENALTY_RATIO = 0;
+    // Rolling count of seasons with a twap above peg.
+    uint256 internal constant INIT_ROLLING_SEASONS_ABOVE_PEG = 0;
+    // Max magnitude for rolling seasons above peg count.
+    uint256 internal constant ROLLING_SEASONS_ABOVE_PEG_CAP = 12;
+    // Rate at which rolling seasons above peg count changes. If not one, it is not actual count.
+    uint256 internal constant ROLLING_SEASONS_ABOVE_PEG_RATE = 1;
 
     // Min Soil Issuance
     uint256 internal constant MIN_SOIL_ISSUANCE = 50e6; // 50
@@ -322,7 +332,7 @@ contract InitalizeDiamond {
 
     function initializeGauges() internal {
         initalizeSeedGauge(INIT_BEAN_TO_MAX_LP_GP_RATIO, INIT_AVG_GSPBDV);
-        // GAUGE //
+
         Gauge memory cultivationFactorGauge = Gauge(
             abi.encode(INIT_CULTIVATION_FACTOR),
             address(this),
@@ -334,7 +344,14 @@ contract InitalizeDiamond {
                 MAX_CULTIVATION_FACTOR
             )
         );
-
         LibGaugeHelpers.addGauge(GaugeId.CULTIVATION_FACTOR, cultivationFactorGauge);
+
+        Gauge memory convertDownPenaltyRatioGauge = Gauge(
+            abi.encode(INIT_CONVERT_DOWN_PENALTY_RATIO, INIT_ROLLING_SEASONS_ABOVE_PEG),
+            address(this),
+            IGaugeFacet.convertDownPenaltyRatioGauge.selector,
+            abi.encode(ROLLING_SEASONS_ABOVE_PEG_RATE, ROLLING_SEASONS_ABOVE_PEG_CAP)
+        );
+        LibGaugeHelpers.addGauge(GaugeId.CONVERT_DOWN_PENALTY_RATIO, convertDownPenaltyRatioGauge);
     }
 }

--- a/contracts/beanstalk/storage/System.sol
+++ b/contracts/beanstalk/storage/System.sol
@@ -346,12 +346,12 @@ struct GaugeData {
 
 /**
  * @notice Gauge is a generic struct that contains the logic for a "gauge".
- * A "gauge" updates a `value` based on some data and its implmentation.
+ * A "gauge" updates a `value` based on some data and its implementation.
  * Any parameter that changes as a function of other parameters can be implemented as a gauge.
- * @param value // value(s) that is being controlled by the gauge. Can be multiple values
+ * @param value value(s) being controlled by the gauge. Can be multiple values.
  * @param target The address in which `selector` is called at.
  * @param selector The logic that changes the gauge value.
- * @param data Additional data that the gauge may ultilize.
+ * @param data Additional data that the gauge may utilize.
  */
 struct Gauge {
     bytes value;
@@ -443,6 +443,7 @@ struct EvaluationParameters {
  * @param abovePegDeltaBSoilScalar The scalar for the time weighted average deltaB when
  * twaDeltaB is negative but beanstalk ended the season above peg.
  * @param soilDistributionPeriod The target period (in seconds) over which to distribute soil (e.g., 24*60*60 for 24 hours).
+ * @param minSoilIssuance The minimum amount of soil to issue in a season when below peg.
  * @param buffer The buffer for future evaluation parameters.
  */
 struct ExtEvaluationParameters {
@@ -490,5 +491,6 @@ enum ShipmentRecipient {
  * @notice The id of the gauge. new gauges should be appended to the end of the enum.
  */
 enum GaugeId {
-    CULTIVATION_FACTOR
+    CULTIVATION_FACTOR,
+    CONVERT_DOWN_PENALTY_RATIO
 }

--- a/contracts/interfaces/IMockFBeanstalk.sol
+++ b/contracts/interfaces/IMockFBeanstalk.sol
@@ -1849,4 +1849,10 @@ interface IMockFBeanstalk {
     function woohoo() external pure returns (uint256);
 
     function wrapEth(uint256 amount, uint8 mode) external payable;
+
+    function downPenalizedGrownStalk(
+        address well,
+        uint256 bdvToConvert,
+        uint256 grownStalkToConvert
+    ) external view returns (uint256 newGrownStalk, uint256 grownStalkLost);
 }

--- a/contracts/libraries/Convert/LibConvert.sol
+++ b/contracts/libraries/Convert/LibConvert.sol
@@ -11,6 +11,7 @@ import {AppStorage, LibAppStorage} from "contracts/libraries/LibAppStorage.sol";
 import {LibWellMinting} from "contracts/libraries/Minting/LibWellMinting.sol";
 import {C} from "contracts/C.sol";
 import {LibRedundantMathSigned256} from "contracts/libraries/Math/LibRedundantMathSigned256.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {LibDeltaB} from "contracts/libraries/Oracle/LibDeltaB.sol";
 import {ConvertCapacity} from "contracts/beanstalk/storage/System.sol";
@@ -18,9 +19,14 @@ import {LibSilo} from "contracts/libraries/Silo/LibSilo.sol";
 import {LibTractor} from "contracts/libraries/LibTractor.sol";
 import {LibGerminate} from "contracts/libraries/Silo/LibGerminate.sol";
 import {LibTokenSilo} from "contracts/libraries/Silo/LibTokenSilo.sol";
-import {GerminationSide} from "contracts/beanstalk/storage/System.sol";
+import {LibEvaluate} from "contracts/libraries/LibEvaluate.sol";
+import {GerminationSide, GaugeId} from "contracts/beanstalk/storage/System.sol";
 import {LibBytes} from "contracts/libraries/LibBytes.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Decimal} from "contracts/libraries/Decimal.sol";
+import {IBeanstalkWellFunction} from "contracts/interfaces/basin/IBeanstalkWellFunction.sol";
+import {IWell, Call} from "contracts/interfaces/basin/IWell.sol";
+import {LibPRBMathRoundable} from "contracts/libraries/Math/LibPRBMathRoundable.sol";
 
 /**
  * @title LibConvert
@@ -31,6 +37,8 @@ library LibConvert {
     using LibWell for address;
     using LibRedundantMathSigned256 for int256;
     using SafeCast for uint256;
+
+    event ConvertDownPenalty(uint256 stalkLost);
 
     struct AssetsRemovedConvert {
         LibSilo.Removed active;
@@ -561,6 +569,63 @@ library LibConvert {
             bdv,
             LibTokenSilo.Transfer.emitTransferSingle
         );
+    }
+
+    /**
+     * @notice Computes new grown stalk after downward convert penalty.
+     * No penalty if P > Q or grown stalk below germination threshold.
+     * @dev Inbound must not be germinating, will return germinating amount of grown stalk.
+     * @return newGrownStalk Amount of grown stalk to assign the deposit.
+     * @return grownStalkLost Amount of grown stalk lost to penalty.
+     */
+    function downPenalizedGrownStalk(
+        address well,
+        uint256 bdv,
+        uint256 grownStalk
+    ) internal view returns (uint256 newGrownStalk, uint256 grownStalkLost) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        // No penalty if output deposit germinating.
+        uint256 minGrownStalk = LibTokenSilo.calculateGrownStalkAtNonGerminatingStem(well, bdv);
+        if (grownStalk < minGrownStalk) {
+            return (grownStalk, 0);
+        }
+
+        // No penalty if P > Q.
+        (uint256[] memory ratios, uint256 beanIndex, bool success) = LibWell.getRatiosAndBeanIndex(
+            IWell(well).tokens(),
+            0
+        );
+        require(success, "Convert: USD Oracle failed");
+        // Scale ratio by Q.
+        ratios[beanIndex] =
+            (ratios[beanIndex] * 1e6) /
+            s.sys.evaluationParameters.excessivePriceThreshold;
+        uint256[] memory cappedReserves = LibDeltaB.cappedReserves(well);
+        Call memory wellFunction = IWell(well).wellFunction();
+        uint256 beansAtPeg = IBeanstalkWellFunction(wellFunction.target)
+            .calcReserveAtRatioLiquidity(cappedReserves, beanIndex, ratios, wellFunction.data);
+        // If more beans in reserves than needed for Q, P > Q.
+        if (beansAtPeg > cappedReserves[beanIndex]) {
+            return (grownStalk, 0);
+        }
+
+        // Get penalty ratio from gauge.
+        (uint256 penaltyRatio, ) = abi.decode(
+            s.sys.gaugeData.gauges[GaugeId.CONVERT_DOWN_PENALTY_RATIO].value,
+            (uint256, uint256)
+        );
+        newGrownStalk = max(
+            grownStalk -
+                LibPRBMathRoundable.mulDiv(
+                    grownStalk,
+                    penaltyRatio,
+                    1e18,
+                    LibPRBMathRoundable.Rounding.Up
+                ),
+            minGrownStalk
+        );
+        grownStalkLost = grownStalk - newGrownStalk;
     }
 
     function abs(int256 a) internal pure returns (uint256) {

--- a/contracts/libraries/LibGaugeHelpers.sol
+++ b/contracts/libraries/LibGaugeHelpers.sol
@@ -39,7 +39,7 @@ library LibGaugeHelpers {
     event UpdatedGauge(GaugeId gaugeId, Gauge gauge);
 
     /**
-     * @notice Calls all Gauges, and updates their values.
+     * @notice Calls all generalized Gauges, and updates their values.
      * @param systemData The system data to pass to the Gauges.
      */
     function engage(bytes memory systemData) internal {
@@ -145,7 +145,7 @@ library LibGaugeHelpers {
     /// GAUGE BLOCKS ///
 
     /**
-     * @notice linear is a implmentation that adds or
+     * @notice linear is a implementation that adds or
      * subtracts an absolute value, as a function of
      * the current value, the amount, and the max and min values.
      */

--- a/contracts/libraries/Well/LibWell.sol
+++ b/contracts/libraries/Well/LibWell.sol
@@ -252,7 +252,21 @@ library LibWell {
      */
     function getBeanUsdPriceForWell(address well) internal view returns (uint256) {
         uint256 tokenBeanPrice = getTokenBeanPriceFromTwaReserves(well);
+        return getBeanUsdPriceFromTokenBeanPrice(well, tokenBeanPrice);
+    }
 
+    /**
+     * @notice Returns the USD price of Bean in a given well.
+     * @dev This function calculates the USD price of Bean by first determining the price of the non-Bean token in the well,
+     * and then using the reserves from the pump to calculate the Bean price.
+     * This can only be called during sunrise.
+     * @param well The address of the well to calculate the Bean USD price for.
+     * @return beanUsdPrice The USD price of Bean in the well.
+     */
+    function getBeanUsdPriceFromTokenBeanPrice(
+        address well,
+        uint256 tokenBeanPrice
+    ) internal view returns (uint256) {
         if (tokenBeanPrice == 0) {
             return 0;
         }
@@ -265,6 +279,27 @@ library LibWell {
         );
 
         return beanUsdPrice;
+    }
+
+    /**
+     * @notice Returns the USD price of Bean in a given well given the reserves.
+     * @param well The address of the well to calculate the Bean USD price for.
+     * @param reserves The reserves of the well. Can be instant, twap, current, etc.
+     * @return beanUsdPrice The USD price of Bean in the well.
+     */
+    function getBeanUsdPriceFromReserves(
+        address well,
+        uint256[] memory reserves
+    ) internal view returns (uint256) {
+        uint256 beanIndex = getBeanIndexFromWell(well);
+        uint256 tokenBeanPrice = calculateTokenBeanPriceFromReserves(
+            well,
+            beanIndex,
+            beanIndex == 0 ? 1 : 0,
+            reserves,
+            IWell(well).wellFunction()
+        );
+        return getBeanUsdPriceFromTokenBeanPrice(well, tokenBeanPrice);
     }
 
     /**

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -608,6 +608,68 @@ task("PI-6", "Deploys Pinto improvment set 6").setAction(async function () {
   });
 });
 
+task("PI-7", "Deploys Pinto improvment set 7, Convert Down Penalty").setAction(async function () {
+  const mock = true;
+  let owner;
+  if (mock) {
+    // await hre.run("updateOracleTimeouts");
+    owner = await impersonateSigner(L2_PCM);
+    await mintEth(owner.address);
+  } else {
+    owner = (await ethers.getSigners())[0];
+  }
+  // upgrade facets
+  await upgradeWithNewFacets({
+    diamondAddress: L2_PINTO,
+    facetNames: [
+      "ConvertFacet",
+      "ConvertGettersFacet",
+      "PipelineConvertFacet",
+      "GaugeFacet",
+      "SeasonFacet",
+      "ApprovalFacet",
+      "SeasonGettersFacet",
+      "ClaimFacet",
+      "SiloGettersFacet",
+      "GaugeGettersFacet",
+      "OracleFacet"
+    ],
+    libraryNames: [
+      "LibConvert",
+      "LibPipelineConvert",
+      "LibSilo",
+      "LibTokenSilo",
+      "LibEvaluate",
+      "LibGauge",
+      "LibIncentive",
+      "LibShipping",
+      "LibWellMinting",
+      "LibFlood",
+      "LibGerminate"
+    ],
+    facetLibraries: {
+      ConvertFacet: ["LibConvert", "LibPipelineConvert", "LibSilo", "LibTokenSilo"],
+      PipelineConvertFacet: ["LibPipelineConvert", "LibSilo", "LibTokenSilo"],
+      SeasonFacet: [
+        "LibEvaluate",
+        "LibGauge",
+        "LibIncentive",
+        "LibShipping",
+        "LibWellMinting",
+        "LibFlood",
+        "LibGerminate"
+      ],
+      SeasonGettersFacet: ["LibWellMinting"],
+      ClaimFacet: ["LibSilo", "LibTokenSilo"]
+    },
+    object: !mock,
+    verbose: true,
+    account: owner,
+    initArgs: [],
+    initFacetName: "InitPI7"
+  });
+});
+
 task("getWhitelistedWells", "Lists all whitelisted wells and their non-pinto tokens").setAction(
   async () => {
     console.log("-----------------------------------");

--- a/test/foundry/convert/convert.t.sol
+++ b/test/foundry/convert/convert.t.sol
@@ -6,7 +6,10 @@ import {TestHelper, LibTransfer, IMockFBeanstalk, C} from "test/foundry/utils/Te
 import {IWell, IERC20} from "contracts/interfaces/basin/IWell.sol";
 import {MockConvertFacet} from "contracts/mocks/mockFacets/MockConvertFacet.sol";
 import {LibConvertData} from "contracts/libraries/Convert/LibConvertData.sol";
+import {GaugeId} from "contracts/beanstalk/storage/System.sol";
+import {BeanstalkPrice} from "contracts/ecosystem/price/BeanstalkPrice.sol";
 import {MockToken} from "contracts/mocks/MockToken.sol";
+import {LibPRBMathRoundable} from "contracts/libraries/Math/LibPRBMathRoundable.sol";
 import "forge-std/console.sol";
 
 /**
@@ -26,8 +29,11 @@ contract ConvertTest is TestHelper {
         uint256 toAmount
     );
 
+    event ConvertDownPenalty(uint256 stalkLost);
+
     // Interfaces.
     MockConvertFacet convert = MockConvertFacet(BEANSTALK);
+    BeanstalkPrice beanstalkPrice = BeanstalkPrice(0xD0fd333F7B30c7925DEBD81B7b7a4DFE106c3a5E);
 
     // MockTokens.
     MockToken weth = MockToken(WETH);
@@ -237,6 +243,296 @@ contract ConvertTest is TestHelper {
 
         // verify deltaB.
         // assertEq(bs.getMaxAmountIn(BEAN, well), deltaB - beansConverted, 'BEAN -> WELL maxAmountIn should be deltaB - beansConverted');
+    }
+
+    function test_convertWithDownPenaltyOnce() public {
+        bean.mint(farmers[0], 20_000e6);
+        bean.mint(0x0000000000000000000000000000000000000001, 200_000e6);
+        vm.prank(farmers[0]);
+        bs.deposit(BEAN, 10_000e6, 0);
+        sowAmountForFarmer(farmers[0], 100_000e6); // Prevent flood.
+        passGermination();
+
+        // Wait some seasons to allow stem tip to advance. More grown stalk to lose.
+        uint256 l2sr;
+        for (uint256 i; i < 580; i++) {
+            warpToNextSeasonAndUpdateOracles();
+            vm.roll(block.number + 1800);
+            l2sr = bs.getLiquidityToSupplyRatio();
+            bs.sunrise();
+        }
+
+        // 1.0 < P < Q.
+        setDeltaBforWell(int256(100e6), BEAN_ETH_WELL, WETH);
+
+        uint256 beansToConvert = 50e6;
+        (
+            bytes memory convertData,
+            int96[] memory stems,
+            uint256[] memory amounts
+        ) = getConvertDownData(well, beansToConvert);
+
+        (uint256 amount, ) = bs.getDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalk = bs.grownStalkForDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalkConverting = (beansToConvert *
+            bs.grownStalkForDeposit(farmers[0], BEAN, int96(0))) / amount;
+        uint256 grownStalkLost = LibPRBMathRoundable.mulDiv(
+            l2sr,
+            grownStalkConverting,
+            1e18,
+            LibPRBMathRoundable.Rounding.Up
+        );
+        assertGt(grownStalkLost, 0, "grownStalkLost should be greater than 0");
+
+        vm.expectEmit();
+        emit ConvertDownPenalty(grownStalkLost);
+
+        vm.prank(farmers[0]);
+        (int96 toStem, , , , ) = convert.convert(convertData, stems, amounts);
+
+        assertGt(toStem, int96(0), "toStem should be larger than initial");
+        uint256 newGrownStalk = bs.grownStalkForDeposit(farmers[0], well, toStem);
+
+        assertLe(newGrownStalk, grownStalkConverting - grownStalkLost, "newGrownStalk too large");
+    }
+
+    function test_convertWithDownPenaltyGerminating() public {
+        bean.mint(farmers[0], 20_000e6);
+        bean.mint(0x0000000000000000000000000000000000000001, 200_000e6);
+        vm.prank(farmers[0]);
+        bs.deposit(BEAN, 10_000e6, 0);
+        sowAmountForFarmer(farmers[0], 100_000e6); // Prevent flood.
+
+        // // LP is still be germinating.
+        // passGermination();
+
+        // 1.0 < P < Q.
+        setDeltaBforWell(int256(100e6), BEAN_ETH_WELL, WETH);
+
+        uint256 beansToConvert = 10e6;
+        (
+            bytes memory convertData,
+            int96[] memory stems,
+            uint256[] memory amounts
+        ) = getConvertDownData(well, beansToConvert);
+
+        // Move forward one season.
+        warpToNextSeasonAndUpdateOracles();
+        vm.roll(block.number + 1800);
+        bs.sunrise();
+
+        // Move forward one season.
+        warpToNextSeasonAndUpdateOracles();
+        vm.roll(block.number + 1800);
+        bs.sunrise();
+
+        // Convert. Bean done germinating, but LP still germinating. No penalty.
+        vm.expectEmit();
+        emit ConvertDownPenalty(0);
+        vm.prank(farmers[0]);
+        convert.convert(convertData, stems, amounts);
+
+        // Move forward one season.
+        warpToNextSeasonAndUpdateOracles();
+        vm.roll(block.number + 1800);
+        uint256 l2sr = bs.getLiquidityToSupplyRatio();
+        bs.sunrise();
+
+        // Convert. LP done germinating. Penalized only the gap from germinating stalk amount.
+        (uint256 amount, ) = bs.getDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalk = bs.grownStalkForDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalkConverting = (beansToConvert *
+            bs.grownStalkForDeposit(farmers[0], BEAN, int96(0))) / amount;
+        uint256 maxGrownStalkLost = LibPRBMathRoundable.mulDiv(
+            l2sr,
+            grownStalkConverting,
+            1e18,
+            LibPRBMathRoundable.Rounding.Up
+        );
+        assertGt(maxGrownStalkLost, 0, "grownStalkLost should be greater than 0");
+        vm.expectEmit(false, false, false, false);
+        emit ConvertDownPenalty(1); // Do not check value match.
+        vm.prank(farmers[0]);
+        (int96 toStem, , , , ) = convert.convert(convertData, stems, amounts);
+
+        uint256 newGrownStalk = bs.grownStalkForDeposit(farmers[0], well, toStem);
+        uint256 stalkLost = grownStalkConverting - newGrownStalk;
+
+        assertGt(stalkLost, 0, "some stalk should be lost");
+        assertLt(stalkLost, maxGrownStalkLost, "stalkLost should be less than maxGrownStalkLost");
+    }
+
+    function test_convertWithDownPenaltyPgtQ() public {
+        bean.mint(farmers[0], 20_000e6);
+        bean.mint(0x0000000000000000000000000000000000000001, 200_000e6);
+        vm.prank(farmers[0]);
+        bs.deposit(BEAN, 10_000e6, 0);
+        sowAmountForFarmer(farmers[0], 100_000e6); // Prevent flood.
+        passGermination();
+
+        // Wait some seasons to allow stem tip to advance. More grown stalk to lose.
+        uint256 l2sr;
+        for (uint256 i; i < 580; i++) {
+            warpToNextSeasonAndUpdateOracles();
+            vm.roll(block.number + 1800);
+            l2sr = bs.getLiquidityToSupplyRatio();
+            bs.sunrise();
+        }
+
+        // 1.0 < Q < P.
+        setDeltaBforWell(int256(1_000e6), BEAN_ETH_WELL, WETH);
+
+        uint256 beansToConvert = 50e6;
+        (
+            bytes memory convertData,
+            int96[] memory stems,
+            uint256[] memory amounts
+        ) = getConvertDownData(well, beansToConvert);
+
+        (uint256 amount, ) = bs.getDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalk = bs.grownStalkForDeposit(farmers[0], BEAN, int96(0));
+        uint256 grownStalkConverting = (beansToConvert *
+            bs.grownStalkForDeposit(farmers[0], BEAN, int96(0))) / amount;
+
+        vm.expectEmit();
+        emit ConvertDownPenalty(0); // No penalty when Q < P.
+
+        vm.prank(farmers[0]);
+        (int96 toStem, , , , ) = convert.convert(convertData, stems, amounts);
+
+        assertGt(toStem, int96(0), "toStem should be larger than initial");
+        uint256 newGrownStalk = bs.grownStalkForDeposit(farmers[0], well, toStem);
+
+        assertLe(newGrownStalk, grownStalkConverting, "newGrownStalk too large");
+    }
+
+    /**
+     * @notice general convert test and verify down convert penalty.
+     */
+    function test_convertBeanToWellWithPenalty() public {
+        bean.mint(farmers[0], 20_000e6);
+        bean.mint(0x0000000000000000000000000000000000000001, 200_000e6);
+        vm.prank(farmers[0]);
+        bs.deposit(BEAN, 10_000e6, 0);
+        sowAmountForFarmer(farmers[0], 100_000e6); // Prevent flood.
+        passGermination();
+
+        // Wait some seasons to allow stem tip to advance. More grown stalk to lose.
+        uint256 l2sr;
+        for (uint256 i; i < 580; i++) {
+            warpToNextSeasonAndUpdateOracles();
+            vm.roll(block.number + 1800);
+            l2sr = bs.getLiquidityToSupplyRatio();
+            bs.sunrise();
+        }
+
+        setDeltaBforWell(int256(100e6), BEAN_ETH_WELL, WETH);
+
+        // create encoding for a bean -> well convert.
+        uint256 beansToConvert = 5e6;
+        (
+            bytes memory convertData,
+            int96[] memory stems,
+            uint256[] memory amounts
+        ) = getConvertDownData(well, beansToConvert);
+
+        int256 totalDeltaB = bs.totalDeltaB();
+        require(totalDeltaB > 0, "totalDeltaB should be greater than 0");
+
+        // initial penalty, when rolling count of seasons above peg is 0 is l2sr.
+        (uint256 lastPenaltyRatio, uint256 rollingSeasonsAbovePeg) = abi.decode(
+            bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+            (uint256, uint256)
+        );
+        assertEq(rollingSeasonsAbovePeg, 0, "rollingSeasonsAbovePeg should be 0");
+
+        assertEq(l2sr, lastPenaltyRatio, "initial penalty ratio should be l2sr at pre sunrise");
+
+        // Convert 13 times, once per season, with an increasing rolling count and a diminishing penalty.
+        int96 lastStem;
+        uint256 lastGrownStalkPerBdv;
+        for (uint256 i; i < 13; i++) {
+            (uint256 newPenaltyRatio, uint256 rollingSeasonsAbovePeg) = abi.decode(
+                bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+                (uint256, uint256)
+            );
+            assertEq(rollingSeasonsAbovePeg, i, "rollingSeasonsAbovePeg incorrect");
+            l2sr = bs.getLiquidityToSupplyRatio();
+
+            vm.prank(farmers[0]);
+            (int96 toStem, , , uint256 fromBdv, ) = convert.convert(convertData, stems, amounts);
+
+            // Penalty when rolling count 0 and 1 is the same.
+            if (i > 1) {
+                assertLt(newPenaltyRatio, lastPenaltyRatio, "penalty ought to be getting smaller");
+                assertLt(toStem, lastStem, "stems ought to be getting lower, penalty smaller");
+            }
+            lastPenaltyRatio = newPenaltyRatio;
+            lastStem = toStem;
+            uint256 newGrownStalkPerBdv = bs.grownStalkForDeposit(
+                farmers[0],
+                BEAN_ETH_WELL,
+                toStem
+            ) / fromBdv;
+            assertGt(
+                newGrownStalkPerBdv,
+                lastGrownStalkPerBdv,
+                "Grown stalk per pdv should increase"
+            );
+            lastGrownStalkPerBdv = newGrownStalkPerBdv;
+            warpToNextSeasonAndUpdateOracles();
+            vm.roll(block.number + 1800);
+            bs.sunrise();
+            require(bs.abovePeg(), "abovePeg should be true");
+        }
+
+        // Test decreasing above peg count.
+        setDeltaBforWell(int256(100e6), BEAN_ETH_WELL, WETH);
+        warpToNextSeasonAndUpdateOracles();
+        bs.sunrise();
+        (lastPenaltyRatio, rollingSeasonsAbovePeg) = abi.decode(
+            bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+            (uint256, uint256)
+        );
+        assertEq(rollingSeasonsAbovePeg, 12, "rollingSeasonsAbovePeg at max");
+        assertEq(0, lastPenaltyRatio, "final penalty should be 0");
+        setDeltaBforWell(int256(-4_000e6), BEAN_ETH_WELL, WETH);
+        uint256 i = 12;
+        while (i > 0) {
+            i--;
+            warpToNextSeasonAndUpdateOracles();
+            vm.roll(block.number + 1800);
+            bs.sunrise();
+            uint256 newPenaltyRatio;
+            (newPenaltyRatio, rollingSeasonsAbovePeg) = abi.decode(
+                bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+                (uint256, uint256)
+            );
+            if (i > 0) {
+                assertEq(rollingSeasonsAbovePeg, i, "rollingSeasonsAbovePeg not decreasing");
+                assertGt(newPenaltyRatio, lastPenaltyRatio, "penalty ought to be getting larger");
+            }
+            lastPenaltyRatio = newPenaltyRatio;
+        }
+        // Confirm min of 0.
+        warpToNextSeasonAndUpdateOracles();
+        vm.roll(block.number + 1800);
+        bs.sunrise();
+        (, rollingSeasonsAbovePeg) = abi.decode(
+            bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+            (uint256, uint256)
+        );
+        assertEq(rollingSeasonsAbovePeg, 0, "rollingSeasonsAbovePeg at min of 0");
+
+        // P > Q.
+        setDeltaBforWell(int256(1_000e6), BEAN_ETH_WELL, WETH);
+        (uint256 newGrownStalk, uint256 grownStalkLost) = bs.downPenalizedGrownStalk(
+            BEAN_ETH_WELL,
+            1_000e6,
+            10_000e18
+        );
+        assertEq(grownStalkLost, 0, "no penalty when P > Q");
+        assertEq(newGrownStalk, 10_000e18, "stalk same when P > Q");
     }
 
     /**
@@ -718,7 +1014,6 @@ contract ConvertTest is TestHelper {
         vm.prank(farmers[0]);
         convert.convert(convertData, new int96[](1), amounts);
 
-
         // assert that the farmer did not lose any rain roots as a result of the convert
         assertEq(
             bs.totalRainRoots(),
@@ -846,4 +1141,27 @@ contract ConvertTest is TestHelper {
     //     assertEq(MockToken(well).totalSupply(), initalLPbalance - lpConverted, 'well LP balance does not equal initalLPbalance - lpConverted');
     //     assertEq(bean.balanceOf(BEANSTALK), initalBeanBalance + expectedAmtOut, 'bean balance does not equal initalBeanBalance + expectedAmtOut');
     // }
+
+    /**
+     * @notice create encoding for a bean -> well convert.
+     */
+    function getConvertDownData(
+        address well,
+        uint256 beansToConvert
+    )
+        private
+        view
+        returns (bytes memory convertData, int96[] memory stems, uint256[] memory amounts)
+    {
+        convertData = convertEncoder(
+            LibConvertData.ConvertKind.BEANS_TO_WELL_LP,
+            well, // well
+            beansToConvert, // amountIn
+            0 // minOut
+        );
+        stems = new int96[](1);
+        stems[0] = int96(0);
+        amounts = new uint256[](1);
+        amounts[0] = beansToConvert;
+    }
 }

--- a/test/foundry/farm/PipelineConvert.t.sol
+++ b/test/foundry/farm/PipelineConvert.t.sol
@@ -7,6 +7,7 @@ import {IMockFBeanstalk} from "contracts/interfaces/IMockFBeanstalk.sol";
 import {MockPump} from "contracts/mocks/well/MockPump.sol";
 import {IWell, Call} from "contracts/interfaces/basin/IWell.sol";
 import {MockToken} from "contracts/mocks/MockToken.sol";
+import {GaugeId} from "contracts/beanstalk/storage/System.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {LibConvert} from "contracts/libraries/Convert/LibConvert.sol";
 import {LibRedundantMath256} from "contracts/libraries/Math/LibRedundantMath256.sol";
@@ -157,8 +158,8 @@ contract PipelineConvertTest is TestHelper {
 
         amount = bound(amount, 10e6, 5000e6);
 
-        // manipulate well so we won't have a penalty applied
-        setDeltaBforWell(int256(amount), beanEthWell, WETH);
+        // manipulate well so we won't have a penalty applied (incl P > Q)
+        setDeltaBforWell(int256(5_000e6), beanEthWell, WETH);
 
         depositBeanAndPassGermination(amount, users[1]);
 
@@ -558,7 +559,8 @@ contract PipelineConvertTest is TestHelper {
     function testConvertWithPegAndKeepStalk(uint256 amount) public {
         amount = bound(amount, 10e6, 100e6);
 
-        setDeltaBforWell(int256(amount), beanEthWell, WETH);
+        // Set P > Q.
+        setDeltaBforWell(1000e6, beanEthWell, WETH);
 
         int96 stem = depositBeanAndPassGermination(amount, users[1]);
 
@@ -566,6 +568,12 @@ contract PipelineConvertTest is TestHelper {
         (, uint256 oldBdv) = bs.getDeposit(users[1], BEAN, stem);
 
         uint256 grownStalkBefore = bs.balanceOfGrownStalk(users[1], BEAN);
+
+        (uint256 downConvertPenaltyRatio, ) = abi.decode(
+            bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+            (uint256, uint256)
+        );
+        assertEq(downConvertPenaltyRatio, 0, "no penalty when P > Q");
 
         beanToLPDoConvert(amount, stem, users[1]);
 
@@ -576,13 +584,49 @@ contract PipelineConvertTest is TestHelper {
         uint256 newBdv = bs.balanceOfDepositedBdv(users[1], beanEthWell); // convert to stalk amount
 
         // calculate grown stalk haircut as a result of fewer BDV deposited
-        uint256 calculatedNewGrownStalk = (newBdv * BDV_TO_STALK) +
+        uint256 calculatedNewStalk = (newBdv * BDV_TO_STALK) +
             ((grownStalkBefore * newBdv) / oldBdv);
 
         assertEq(
             balanceOfStalk + balanceOfGerminatingStalk,
-            calculatedNewGrownStalk,
-            "all grown stalk was not kept"
+            calculatedNewStalk,
+            "stalk beyond the convert down penalty was lost"
+        );
+    }
+
+    function testConvertWithPegAndOnlyDownConvertStalkLoss(uint256 amount) public {
+        amount = bound(amount, 10e6, 100e6);
+
+        setDeltaBforWell(int256(amount), beanEthWell, WETH);
+
+        int96 stem = depositBeanAndPassGermination(amount, users[1]);
+
+        // get bdv of amount
+        (, uint256 oldBdv) = bs.getDeposit(users[1], BEAN, stem);
+
+        uint256 grownStalkBefore = bs.balanceOfGrownStalk(users[1], BEAN);
+
+        (uint256 downConvertPenaltyRatio, ) = abi.decode(
+            bs.getGaugeValue(GaugeId.CONVERT_DOWN_PENALTY_RATIO),
+            (uint256, uint256)
+        );
+
+        beanToLPDoConvert(amount, stem, users[1]);
+
+        uint256 balanceOfStalk = bs.balanceOfStalk(users[1]);
+        uint256 balanceOfGerminatingStalk = bs.balanceOfGerminatingStalk(users[1]);
+
+        // get balance of deposited bdv for this user
+        uint256 newBdv = bs.balanceOfDepositedBdv(users[1], beanEthWell); // convert to stalk amount
+
+        // calculate grown stalk haircut as a result of fewer BDV deposited
+        uint256 calculatedNewStalk = (newBdv * BDV_TO_STALK) +
+            ((grownStalkBefore * newBdv * (1e18 - downConvertPenaltyRatio)) / oldBdv / 1e18);
+
+        assertEq(
+            balanceOfStalk + balanceOfGerminatingStalk,
+            calculatedNewStalk,
+            "stalk beyond the convert down penalty was lost"
         );
     }
 


### PR DESCRIPTION
# PI-7: Convert Down Penalty

## Problem

Pinto tends to spend more Seasons below its value target than above it. As a result, opportunities to Convert downward (*i.e.*, from Pinto to LP Deposits) are more limited than opportunities to Convert upward (*i.e.*, from LP to Pinto Deposits). This results in a significantly stronger incentive to Convert downward when the opportunity is available even when no Seeds are gained (or even, when Seeds are lost).

This race to Convert downward also favors users with automated execution, concentrating the distribution of LP Deposits (and the Stalk earned from these Conversions) to these users.

## Solution

Introduce a Grown Stalk penalty to Conversions downward as a function of the L2SR and a rolling value determined by whether previous Seasons were spent above or below the value target. The penalty ranges from 0% to 100% of the Grown Stalk of the Converted Deposit.

A dynamic Grown Stalk penalty for downward Converts creates a competitive market that favors new Deposits (due to their lower Grown Stalk), reducing ownership concentration of LP Deposits and the Stalk earned via Conversions. In essence, Converters effectively bid on how much Grown Stalk they are willing to pay for the privilege of Converting downward.

The Excessively High Price threshold ($P^{\text{upper}}$) should be decreased to account for the higher volatility above the value target that this Grown Stalk penalty potentially introduces.

## Implementation

### Convert Down Penalty Gauge System

Add a `CONVERT_DOWN_PENALTY_RATIO` gauge system that updates the Grown Stalk penalty incurred by Conversions from Pinto to LP Deposits above the value target.

We define the Grown Stalk Penalty Factor in Season $t$ ($G_{t}$) for a given Season of PI-7 deployment ($\circ$), maximum Grown Stalk Penalty Factor ($\mathfrak{G}^{\mathrm{max}}$, where $\mathfrak{G}^{\mathrm{max}} = 12$), and time-weighted average deltaP over the previous Season ($\Delta B_{\overline{t-1}}$) as:

![Equation](https://latex.codecogs.com/svg.image?$$\mathfrak{G}_{t}=\begin{cases}0&\text{if}t==1\mkern6mu||\mkern6mu&space;t==\circ\\\min(\mathfrak{G}^{\text{max}},\mathfrak{G}_{t-1}&plus;1)&\text{if}\Delta&space;B_{\overline{t-1}}>0\\\max(0,\mathfrak{G}_{t-1}-1)&\text{otherwise}\end{cases}$$)



Therefore, we define the percent Grown Stalk Penalty for Converting Pinto to LP Deposits above the value target ($g^{\*}$) for a given liquidity and time weighted average price over the previous Season ($P_{\overline{t-1}}$), $P^{\text{upper}}$, $\mathfrak{G}_{t}$, L2SR over the previous Season ($R^{W}$), optimal L2SR ($R^{W^{*}}$), and $\mathfrak{G}^{\text{max}}$ as:

 ![Equation](https://latex.codecogs.com/svg.image?$$g^{*}=\begin{cases}0&\text{if}P_{\overline{t-1}}>P^{\text{upper}}\\\\max(0,\frac{\min(R^{W},R^{W^{*}})}{R^{W^{*}}}\times(1-\frac{\log_2(\mathfrak{G}_{t}&plus;1)}{\log_2(\mathfrak{G}^{\text{max}}&plus;1)}))&\text{otherwise}\end{cases}$$)

![CleanShot 2025-03-21 at 15.38.29@2x](https://hackmd.io/_uploads/rJAabSj2ke.png)

The chart shows the decaying Grown Stalk Penalty as Seasons are spent above the value target:
* The blue line shows the penalty when $R^{W}$ is greater than or equal to 40%;
* The purple line shows the penalty when $R^{W}$ is equal to 20%; and
* The green line shows the penalty when $R^{W}$ is equal to 10%.

### Decrease Excessively High Price Threshold

Decrease $P^{\text{upper}}$ (`excessivePriceThreshold`) from $1.05 to $1.025.
