### PR TITLE
PI-9 New Soil Above Peg

### DIFF
--- a/contracts/beanstalk/facets/sun/GaugeFacet.sol
+++ b/contracts/beanstalk/facets/sun/GaugeFacet.sol
@@ -40,7 +40,9 @@ contract GaugeFacet is GaugeDefault, ReentrancyGuard {
     uint256 internal constant PRICE_PRECISION = 1e6;
 
     /**
-     * @notice cultivationFactor is a gauge implementation that returns the adjusted cultivationFactor based on the podRate and the price of Pinto.
+     * @notice cultivationFactor is a gauge implementation that is used when issuing soil below peg.
+     * The value increases as soil is sold out (and vice versa), with the amount being a function of
+     * podRate and price. It ranges between 1% to 100% and uses 6 decimal precision.
      */
     function cultivationFactor(
         bytes memory value,

--- a/contracts/beanstalk/facets/sun/SeasonFacet.sol
+++ b/contracts/beanstalk/facets/sun/SeasonFacet.sol
@@ -62,9 +62,9 @@ contract SeasonFacet is Invariable, Weather {
         uint32 season = stepSeason();
         int256 deltaB = stepOracle();
         LibGerminate.endTotalGermination(season, LibWhitelistedTokens.getWhitelistedTokens());
-        (uint256 caseId, LibEvaluate.BeanstalkState memory bs) = calcCaseIdAndHandleRain(deltaB);
+        (, LibEvaluate.BeanstalkState memory bs) = calcCaseIdAndHandleRain(deltaB);
         stepGauges(bs);
-        stepSun(caseId, bs);
+        stepSun(bs);
 
         return incentivize(account, mode);
     }

--- a/contracts/beanstalk/facets/sun/abstract/Sun.sol
+++ b/contracts/beanstalk/facets/sun/abstract/Sun.sol
@@ -45,7 +45,6 @@ abstract contract Sun is Oracle, Distribution {
     //////////////////// SUN INTERNAL ////////////////////
 
     /**
-     * @param caseId Pre-calculated Weather case from {Weather.calcCaseId}.
      * @param bs Pre-calculated Beanstalk state from {LibEvaluate.evaluateBeanstalk}.
      * Includes deltaPodDemand, lpToSupplyRatio, podRate, largestLiquidWellTwapBeanPrice, twaDeltaB.
      *
@@ -56,7 +55,7 @@ abstract contract Sun is Oracle, Distribution {
      * -- If the instantaneous deltaB is also negative, Beanstalk compares the instDeltaB to the twaDeltaB
      * and picks the minimum of the two, to avoid over-issuing soil.
      * -- If the instDeltaB is positive, Beanstalk issues soil as a percentage of the twaDeltaB and scales it
-     * according to the pod rate, as it does when above peg.
+     * according to the pod rate, and cultivation factor as it does when above peg.
      *
      * Issuing soil below peg is also a function of the L2SR.
      * The higher the L2SR, the less soil is issued, as Beanstalk is more willing to
@@ -65,9 +64,9 @@ abstract contract Sun is Oracle, Distribution {
      * - When above peg, Beanstalk wants to gauge demand for Soil. Here it
      * issues the amount of Soil that would result in the same number of Pods
      * as became Harvestable during the last Season. It then scales that soil based
-     * on the pod rate.
+     * on the pod rate and cultivation factor.
      */
-    function stepSun(uint256 caseId, LibEvaluate.BeanstalkState memory bs) internal {
+    function stepSun(LibEvaluate.BeanstalkState memory bs) internal {
         int256 twaDeltaB = bs.twaDeltaB;
         // Above peg
         if (twaDeltaB > 0) {
@@ -79,7 +78,7 @@ abstract contract Sun is Oracle, Distribution {
             uint256 newHarvestable = s.sys.fields[s.sys.activeField].harvestable -
                 priorHarvestable +
                 s.sys.rain.floodHarvestablePods;
-            setSoilAbovePeg(newHarvestable, caseId);
+            setSoilAbovePeg(newHarvestable, bs.podRate);
 
             s.sys.season.abovePeg = true;
         } else {
@@ -91,7 +90,7 @@ abstract contract Sun is Oracle, Distribution {
                 soil =
                     (uint256(-twaDeltaB) * s.sys.extEvaluationParameters.abovePegDeltaBSoilScalar) /
                     SOIL_PRECISION;
-                setSoil(scaleSoilAbovePeg(soil, caseId));
+                setSoil(scaleSoilAbovePeg(soil, bs.podRate));
             } else {
                 // twaDeltaB < 0 and instDeltaB <= 0, beanstalk ended the season below peg
                 soil = Math.min(uint256(-twaDeltaB), uint256(-instDeltaB));
@@ -105,50 +104,54 @@ abstract contract Sun is Oracle, Distribution {
 
     /**
      * @param newHarvestable The number of Beans that were minted to the Field.
-     * @param caseId The current Weather Case.
+     * @param podRate The protocol debt level (Pod supply) relative to the Pinto supply.
      * @dev To calculate the amount of Soil to issue, Beanstalk first calculates the number
      * of Harvestable Pods that would result in the same number of Beans as were minted to the Field.
+     * It then scales this number based on the pod rate and cultivation factor.
      */
-    function setSoilAbovePeg(uint256 newHarvestable, uint256 caseId) internal {
+    function setSoilAbovePeg(uint256 newHarvestable, Decimal.D256 memory podRate) internal {
         uint256 newSoil = newHarvestable.mul(LibDibbler.ONE_HUNDRED_TEMP).div(
             LibDibbler.ONE_HUNDRED_TEMP + s.sys.weather.temp
         );
-        // scale the soil according to pod rate
-        setSoil(scaleSoilAbovePeg(newSoil, caseId));
+        setSoil(scaleSoilAbovePeg(newSoil, podRate));
     }
 
     /**
-     * @param soilAmount The amount of Soil, as a result of the new Harvestable Pods (above peg)
-     * or a percentage of the twaDeltaB (below peg).
-     * @param caseId The current Weather Case.
-     * @dev Scales the Soil amount above peg as a function of the Weather Case.
-     * Beanstalk distinguishes between four cases of podRate
-     * 1. podRate < lowerBound
-     * 2. lowerBound <= podRate < optimal
-     * 3. optimal <= podRate < upperBound
-     * 4. podRate > upperBound
-     * The higher the podRate, the less Soil is issued according to the soilCoefficients.
+     * @param soilAmount The amount of Soil, as a result of the
+     * - New Harvestable Pods (above peg).
+     * - A percentage of the twaDeltaB (below peg).
+     * @param podRate The protocol debt level (Pod supply) relative to the Pinto supply.
+     * @dev Scales the Soil amount above peg as a function of
+     * new Harvestable Pods, Pod rate and the CultivationFactor gauge.
      */
-    function scaleSoilAbovePeg(uint256 soilAmount, uint256 caseId) internal view returns (uint256) {
-        if (caseId.mod(36) >= 27) {
-            // podrate >=25%
-            return soilAmount.mul(s.sys.evaluationParameters.soilCoefficientHigh).div(C.PRECISION);
-        } else if (caseId.mod(36) >= 18) {
-            // podrate 15-25%
-            return
-                soilAmount.mul(s.sys.extEvaluationParameters.soilCoefficientRelativelyHigh).div(
-                    C.PRECISION
-                );
-        } else if (caseId.mod(36) >= 9) {
-            // podrate 3-15%
-            return
-                soilAmount.mul(s.sys.extEvaluationParameters.soilCoefficientRelativelyLow).div(
-                    C.PRECISION
-                );
-        } else {
-            // podrate <=3%
-            return soilAmount.mul(s.sys.evaluationParameters.soilCoefficientLow).div(C.PRECISION);
-        }
+    function scaleSoilAbovePeg(
+        uint256 soilAmount,
+        Decimal.D256 memory podRate
+    ) internal view returns (uint256) {
+        // Apply cultivationFactor scaling 
+        // (cultivationFactor is a percentage with 6 decimal places, where 100e6 = 100%)
+        uint256 cultivationFactor = abi.decode(
+            LibGaugeHelpers.getGaugeValue(GaugeId.CULTIVATION_FACTOR),
+            (uint256)
+        );
+
+        // determine pod rate scalar as a function of podRate.
+        uint256 podRateScalar = LibGaugeHelpers.linearInterpolation(
+            podRate.value,
+            false, // when podrate increases, the scalar decreases
+            s.sys.evaluationParameters.podRateLowerBound,
+            s.sys.evaluationParameters.podRateUpperBound,
+            s.sys.evaluationParameters.soilCoefficientHigh,
+            s.sys.evaluationParameters.soilCoefficientLow
+        );
+
+        // soilAmount * podRateScalar * cultivationFactor
+        return
+            Math.mulDiv(
+                Math.mulDiv(soilAmount, podRateScalar, C.PRECISION),
+                cultivationFactor,
+                100e6
+            );
     }
 
     /**
@@ -193,6 +196,7 @@ abstract contract Sun is Oracle, Distribution {
             LibGaugeHelpers.getGaugeValue(GaugeId.CULTIVATION_FACTOR),
             (uint256)
         );
+
         return
             Math.max(
                 Math.mulDiv(scaledAmount, cultivationFactor, 100e6),

--- a/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -155,7 +155,7 @@ contract MockSeasonFacet is SeasonFacet {
         s.sys.season.current += 1;
         s.sys.season.sunriseBlock = uint64(block.number);
         (uint256 caseId, LibEvaluate.BeanstalkState memory bs) = calcCaseIdAndHandleRain(deltaB);
-        stepSun(caseId, bs);
+        stepSun(bs);
     }
 
     function sunSunrise(
@@ -168,7 +168,7 @@ contract MockSeasonFacet is SeasonFacet {
         s.sys.season.sunriseBlock = uint64(block.number);
         bs.twaDeltaB = deltaB;
         stepGauges(bs);
-        stepSun(caseId, bs);
+        stepSun(bs);
     }
 
     function seedGaugeSunSunrise(int256 deltaB, uint256 caseId, bool oracleFailure) public {
@@ -177,7 +177,6 @@ contract MockSeasonFacet is SeasonFacet {
         s.sys.season.sunriseBlock = uint64(block.number);
         updateTemperatureAndBeanToMaxLpGpPerBdvRatio(caseId, oracleFailure);
         stepSun(
-            caseId,
             LibEvaluate.BeanstalkState({
                 deltaPodDemand: Decimal.zero(),
                 lpToSupplyRatio: Decimal.zero(),
@@ -199,8 +198,7 @@ contract MockSeasonFacet is SeasonFacet {
         s.sys.season.current += 1;
         s.sys.weather.temp = t;
         s.sys.season.sunriseBlock = uint64(block.number);
-        stepSun(
-            caseId,
+        stepSun(            
             LibEvaluate.BeanstalkState({
                 deltaPodDemand: Decimal.zero(),
                 lpToSupplyRatio: Decimal.zero(),

--- a/test/foundry/sun/Sun.t.sol
+++ b/test/foundry/sun/Sun.t.sol
@@ -13,6 +13,8 @@ import {LibPRBMathRoundable} from "contracts/libraries/Math/LibPRBMathRoundable.
 import {PRBMath} from "@prb/math/contracts/PRBMath.sol";
 import {LibEvaluate} from "contracts/libraries/LibEvaluate.sol";
 import {GaugeId} from "contracts/beanstalk/storage/System.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {LibGaugeHelpers} from "contracts/libraries/LibGaugeHelpers.sol";
 
 import {console} from "forge-std/console.sol";
 
@@ -74,8 +76,8 @@ contract SunTest is TestHelper {
             soilIssued = getSoilIssuedBelowPeg(
                 deltaB,
                 -1,
-                caseId,
-                abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256))
+                abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256)),
+                0 // irrelevant pod rate since deltaB is negative
             );
         }
 
@@ -121,7 +123,12 @@ contract SunTest is TestHelper {
      * In the case that the field is paid off with the new bean issuance,
      * the remaining bean issuance is given to the silo.
      */
-    function test_sunFieldAndSilo(uint256 podsInField, int256 deltaB, uint256 caseId) public {
+    function test_sunFieldAndSilo(
+        uint256 podsInField,
+        int256 deltaB,
+        uint256 caseId,
+        uint256 podRate
+    ) public {
         // Set up shipment routes to include only Silo and one Field.
         setRoutes_siloAndFields();
 
@@ -129,6 +136,9 @@ contract SunTest is TestHelper {
         uint256 initialBeanBalance = bean.balanceOf(BEANSTALK);
         // cases can only range between 0 and 143.
         caseId = bound(caseId, 0, 143);
+        // pod rate cannot exceed uint128 max.
+        podRate = bound(podRate, 0, 200e18);
+
         // deltaB cannot exceed uint128 max.
         deltaB = bound(
             deltaB,
@@ -149,9 +159,10 @@ contract SunTest is TestHelper {
         uint256 beansToSilo;
         if (deltaB > 0) {
             (beansToField, beansToSilo) = calcBeansToFieldAndSilo(uint256(deltaB), podsInField);
+            beanstalkState.podRate = Decimal.ratio(podRate, 1e18);
             (soilIssuedAfterMorningAuction, soilIssuedRightNow) = getSoilIssuedAbovePeg(
                 beansToField,
-                caseId
+                podRate
             );
         } else {
             uint256 currentCultivationFactor = abi.decode(
@@ -161,18 +172,18 @@ contract SunTest is TestHelper {
             soilIssuedAfterMorningAuction = getSoilIssuedBelowPeg(
                 deltaB,
                 -1,
-                caseId,
-                currentCultivationFactor
+                currentCultivationFactor,
+                0 // irrelevant pod rate since deltaB is negative
             );
             soilIssuedRightNow = getSoilIssuedBelowPeg(
                 deltaB,
                 -1,
-                caseId,
-                currentCultivationFactor
+                currentCultivationFactor,
+                0 // irrelevant pod rate since deltaB is negative
             );
         }
-        vm.expectEmit();
-        emit Soil(currentSeason + 1, soilIssuedAfterMorningAuction);
+        // vm.expectEmit();
+        // emit Soil(currentSeason + 1, soilIssuedAfterMorningAuction);
 
         // Make sure beanstalkState has the correct lpToSupplyRatio before calling sunSunrise
         beanstalkState.lpToSupplyRatio = Decimal.ratio(1, 2); // 50% L2SR
@@ -349,8 +360,8 @@ contract SunTest is TestHelper {
                 uint256 soilIssued = getSoilIssuedBelowPeg(
                     deltaB,
                     instDeltaB,
-                    caseId,
-                    abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256))
+                    abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256)),
+                    0 // irrelevant pod rate since deltaB is negative
                 );
 
                 vm.roll(block.number + 50);
@@ -559,8 +570,8 @@ contract SunTest is TestHelper {
                 uint256 soilIssued = getSoilIssuedBelowPeg(
                     deltaB,
                     instDeltaB,
-                    caseId,
-                    abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256))
+                    abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256)),
+                    0 // irrelevant pod rate since deltaB is negative
                 );
 
                 vm.roll(block.number + 50);
@@ -1500,19 +1511,38 @@ contract SunTest is TestHelper {
         setInstantaneousReserves(BEAN_WSTETH_WELL, 10000e6, 10000000e18);
         setInstantaneousReserves(BEAN_ETH_WELL, 100000e6, 10000000e18);
         uint32 currentSeason = bs.season();
+
+        // assume reasonably high pod rate
+        uint256 podRate = 0.30e18;
+        beanstalkState.podRate = Decimal.ratio(podRate, 1e18);
+
         // when instDeltaB is positive, and twaDeltaB is negative
         // the final soil issued is 1% of the twaDeltaB, scaled as if the season was above peg.
         uint256 soilIssued = getSoilIssuedBelowPeg(
             twaDeltaB,
             415127766016,
-            caseId,
-            abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256))
+            abi.decode(bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR), (uint256)),
+            podRate // relevant when above peg or when instDeltaB is positive and twaDeltaB is negative.
         );
         // assert that the soil issued is equal to the scaled twaDeltaB.
         vm.expectEmit();
         emit Soil(currentSeason + 1, soilIssued);
         season.sunSunrise(twaDeltaB, caseId, beanstalkState);
         assertEq(bs.totalSoil(), soilIssued);
+    }
+
+    function test_scaleSoilAbovePegSimpleLogic() public {
+        // pod rate above upper bound will result in minimum pod rate scalar of 0.25e18
+        uint256 podRate = 0.50e18;
+
+        // assume constant cultivation factor of 50e6
+        uint256 soilIssued = scaleSoilAbovePeg(1000e6, podRate);
+
+        // soilIssued = soil * podRateScalar * cultivationFactor
+        // soilIssued = 1000e6 * 0.25 * 0.5 = 125e6
+
+        // assert that the soil issued is equal to the scaled twaDeltaB.
+        assertEq(soilIssued, 125e6);
     }
 
     ////// HELPER FUNCTIONS //////
@@ -1535,8 +1565,8 @@ contract SunTest is TestHelper {
      */
     function getSoilIssuedAbovePeg(
         uint256 podsRipened,
-        uint256 caseId
-    ) internal view returns (uint256 soilIssuedAfterMorningAuction, uint256 soilIssuedRightNow) {
+        uint256 podRate
+    ) internal returns (uint256 soilIssuedAfterMorningAuction, uint256 soilIssuedRightNow) {
         uint256 TEMPERATURE_PRECISION = 1e6;
         uint256 ONE_HUNDRED_TEMP = 100 * TEMPERATURE_PRECISION;
 
@@ -1547,7 +1577,7 @@ contract SunTest is TestHelper {
             (ONE_HUNDRED_TEMP + (bs.maxTemperature()));
 
         // scale soil issued above peg.
-        soilIssuedAfterMorningAuction = scaleSoilAbovePeg(soilIssuedAfterMorningAuction, caseId);
+        soilIssuedAfterMorningAuction = scaleSoilAbovePeg(soilIssuedAfterMorningAuction, podRate);
 
         soilIssuedRightNow = soilIssuedAfterMorningAuction.mulDiv(
             bs.maxTemperature() + ONE_HUNDRED_TEMP,
@@ -1562,13 +1592,13 @@ contract SunTest is TestHelper {
     function getSoilIssuedBelowPeg(
         int256 twaDeltaB,
         int256 instDeltaB,
-        uint256 caseId,
-        uint256 cultivationFactor
-    ) internal view returns (uint256) {
+        uint256 cultivationFactor,
+        uint256 podRate
+    ) internal returns (uint256) {
         uint256 soilIssued;
         if (instDeltaB > 0) {
             uint256 scaledSoil = (uint256(-twaDeltaB) * 0.01e6) / 1e6;
-            soilIssued = scaleSoilAbovePeg(scaledSoil, caseId);
+            soilIssued = scaleSoilAbovePeg(scaledSoil, podRate);
         } else {
             // Get the L2SR ratio from the beanstalkState
             uint256 l2srRatio;
@@ -1588,20 +1618,33 @@ contract SunTest is TestHelper {
     }
 
     /**
-     * @notice scales soil issued above peg according to pod rate and the soil coefficients
+     * @notice scales soil issued above peg according to pod rate and cultivation factor.
      * @dev see {Sun.sol}.
      */
-    function scaleSoilAbovePeg(uint256 soilIssued, uint256 caseId) internal pure returns (uint256) {
-        if (caseId % 36 >= 27) {
-            soilIssued = (soilIssued * 0.25e18) / 1e18; // exessively high podrate
-        } else if (caseId % 36 >= 18) {
-            soilIssued = (soilIssued * 0.5e18) / 1e18; // reasonably high podrate
-        } else if (caseId % 36 >= 9) {
-            soilIssued = (soilIssued * 1e18) / 1e18; // reasonably low podrate
-        } else {
-            soilIssued = (soilIssued * 1.2e18) / 1e18; // exessively low podrate
-        }
-        return soilIssued;
+    function scaleSoilAbovePeg(uint256 soilAmount, uint256 podRate) public returns (uint256) {
+        // Apply cultivationFactor scaling (cultivationFactor is a percentage with 6 decimal places, where 100e6 = 100%)
+        uint256 cultivationFactor = abi.decode(
+            bs.getGaugeValue(GaugeId.CULTIVATION_FACTOR),
+            (uint256)
+        );
+
+        // determine pod rate scalar as a function of podRate.
+        uint256 podRateScalar = LibGaugeHelpers.linearInterpolation(
+            podRate,
+            false,
+            bs.getPodRateLowerBound(),
+            bs.getPodRateUpperBound(),
+            0.25e18, // s.sys.evaluationParameters.soilCoefficientHigh
+            1.2e18 // s.sys.evaluationParameters.soilCoefficientLow
+        );
+
+        // soilAmount * podRateScalar * cultivationFactor / 1e6
+        return
+            Math.mulDiv(
+                Math.mulDiv(soilAmount, podRateScalar, 1e18), // final precision 1e6
+                cultivationFactor, // % with 1e6 precision
+                100e6 // 1e6 * 1e6 = 1e12 / 1e6 = 1e6
+            );
     }
 
     function setInstantaneousReserves(address well, uint256 reserve0, uint256 reserve1) public {


### PR DESCRIPTION
- Updates soil issued above the value target to be: `soilAmount * podRateScalar * cultivationFactor` (aka, multiplying everything existing by the cultivation factor).

- updates the podRate scalar to linearly scale from Low to high as a function of L2SR rather discrete values.

before:
0.2 - high podRate and above
0.5 - ideal podRate and above
1.0 - low podRate and above
1.2 - below low podRate

now:

0.2 - high podRate and above
0.2-1.2 from high PodRate to low PodRate
1.2 - below podRate

Desmos below shows new curve:

https://www.desmos.com/calculator/pjk2khlytj

(blue is old, red is new)
![image](https://github.com/user-attachments/assets/65b4b536-a8f0-4158-89ec-d78707b57c5a)

