### PR TITLE
PI-9 Soil Demand Changes 

### DIFF
--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -41,10 +41,7 @@ jobs:
 
       - name: Install Libraries
         run: |
-          forge install https://github.com/foundry-rs/forge-std@07263d1
-          forge install https://github.com/OpenZeppelin/openzeppelin-contracts@fd81a96
-          forge install https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@3d4c0d5
-          forge install https://github.com/paulrberg/prb-math@2c59739
+          forge install
 
       - name: Run Forge build
         run: |

--- a/contracts/beanstalk/facets/sun/abstract/Sun.sol
+++ b/contracts/beanstalk/facets/sun/abstract/Sun.sol
@@ -203,9 +203,12 @@ abstract contract Sun is Oracle, Distribution {
     /**
      * @param amount The new amount of Soil available.
      * @dev Sets the amount of Soil available and emits a Soil event.
+     * Also sets the initialSoil amount as s.sys.soil gets decremented when sowing.
+     * initialSoil gets used to calculate deltaPodDemand and amount needed to consider soil sold out.
      */
     function setSoil(uint256 amount) internal {
         s.sys.soil = amount.toUint128();
+        s.sys.initialSoil = s.sys.soil;
         emit Soil(s.sys.season.current, amount.toUint128());
     }
 }

--- a/contracts/beanstalk/init/InitPI7.sol
+++ b/contracts/beanstalk/init/InitPI7.sol
@@ -1,0 +1,19 @@
+/*
+ SPDX-License-Identifier: MIT
+*/
+
+pragma solidity ^0.8.20;
+import "../../libraries/LibAppStorage.sol";
+
+/**
+ * @title InitPI7`.
+ * @dev Initializes parameters for pinto improvement set 7
+ **/
+contract InitPI7 {
+    function init() external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        s.sys.extEvaluationParameters.supplyPodDemandScalar = 0.00001e6; // 0.001%
+        s.sys.extEvaluationParameters.initialSoilPodDemandScalar = 0.25e6; // 25%
+    }
+}

--- a/contracts/beanstalk/init/InitalizeDiamond.sol
+++ b/contracts/beanstalk/init/InitalizeDiamond.sol
@@ -317,6 +317,9 @@ contract InitalizeDiamond {
 
         // Initialize soilDistributionPeriod to 24 hours (in seconds)
         s.sys.extEvaluationParameters.soilDistributionPeriod = SOIL_DISTRIBUTION_PERIOD;
+
+        s.sys.extEvaluationParameters.supplyPodDemandScalar = SUPPLY_POD_DEMAND_SCALAR;
+        s.sys.extEvaluationParameters.initialSoilPodDemandScalar = INITIAL_SOIL_POD_DEMAND_SCALAR;
     }
 
     function initalizeFarmAndTractor() internal {

--- a/contracts/beanstalk/init/InitalizeDiamond.sol
+++ b/contracts/beanstalk/init/InitalizeDiamond.sol
@@ -93,6 +93,10 @@ contract InitalizeDiamond {
     // Min Soil Issuance
     uint256 internal constant MIN_SOIL_ISSUANCE = 50e6; // 50
 
+    // Pod Demand Scalars
+    uint256 internal constant INITIAL_SOIL_POD_DEMAND_SCALAR = 0.25e6; // 25%
+    uint256 internal constant SUPPLY_POD_DEMAND_SCALAR = 0.00001e6; // 0.001%
+
     // EVENTS:
     event BeanToMaxLpGpPerBdvRatioChange(uint256 indexed season, uint256 caseId, int80 absChange);
 

--- a/contracts/beanstalk/storage/System.sol
+++ b/contracts/beanstalk/storage/System.sol
@@ -53,7 +53,8 @@ struct System {
     uint256 activeField;
     uint256 fieldCount;
     uint256 orderLockedBeans;
-    bytes32[16] _buffer_0;
+    uint256 initialSoil;
+    bytes32[15] _buffer_0;
     mapping(uint256 => mapping(uint256 => bytes32)) podListings;
     mapping(bytes32 => uint256) podOrders;
     mapping(IERC20 => uint256) internalTokenBalanceTotal;
@@ -443,6 +444,9 @@ struct EvaluationParameters {
  * @param abovePegDeltaBSoilScalar The scalar for the time weighted average deltaB when
  * twaDeltaB is negative but beanstalk ended the season above peg.
  * @param soilDistributionPeriod The target period (in seconds) over which to distribute soil (e.g., 24*60*60 for 24 hours).
+ * @param minSoilIssuance The minimum amount of soil that can be issued in a season.
+ * @param supplyPodDemandScalar The scalar to scale the bean supply by when evaluating the delta pod demand.
+ * @param initialSoilPodDemandScalar The scalar to scale the initial soil issuance by when evaluating the delta pod demand.
  * @param buffer The buffer for future evaluation parameters.
  */
 struct ExtEvaluationParameters {
@@ -452,7 +456,9 @@ struct ExtEvaluationParameters {
     uint256 abovePegDeltaBSoilScalar;
     uint256 soilDistributionPeriod;
     uint256 minSoilIssuance;
-    bytes32[61] buffer;
+    uint256 supplyPodDemandScalar;
+    uint256 initialSoilPodDemandScalar;
+    bytes32[59] buffer;
 }
 
 /**

--- a/contracts/interfaces/IMockFBeanstalk.sol
+++ b/contracts/interfaces/IMockFBeanstalk.sol
@@ -1597,6 +1597,8 @@ interface IMockFBeanstalk {
 
     function setYieldE(uint256 t) external;
 
+    function setBeansSownE(uint128 amount) external;
+
     function setCultivationFactor(uint256 cultivationFactor) external;
 
     function siloSunrise(uint256 amount) external;

--- a/contracts/libraries/LibEvaluate.sol
+++ b/contracts/libraries/LibEvaluate.sol
@@ -363,6 +363,7 @@ library LibEvaluate {
         uint256 calculatedThreshold = (beanSupply *
             s.sys.extEvaluationParameters.supplyPodDemandScalar) / BEAN_PRECISION;
 
+        // take the maximum of the calculated threshold and the minimum supply bound.
         uint256 beanSupplyThreshold = calculatedThreshold > MIN_BEAN_SUPPLY_BOUND
             ? calculatedThreshold
             : MIN_BEAN_SUPPLY_BOUND;
@@ -371,7 +372,8 @@ library LibEvaluate {
         uint256 scaledInitialSoil = (s.sys.initialSoil *
             s.sys.extEvaluationParameters.initialSoilPodDemandScalar) / SOIL_PRECISION;
 
-        minDemandThreshold = beanSupplyThreshold > scaledInitialSoil
+        // take the minimum of the scaled initial soil and the bean supply threshold.
+        minDemandThreshold = beanSupplyThreshold < scaledInitialSoil
             ? beanSupplyThreshold
             : scaledInitialSoil;
     }

--- a/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -301,6 +301,10 @@ contract MockSeasonFacet is SeasonFacet {
         setSoil(amount);
     }
 
+    function setBeansSownE(uint128 amount) public {
+        s.sys.beanSown = amount;
+    }
+
     function resetState() public {
         for (uint256 i; i < s.sys.fieldCount; i++) {
             s.sys.fields[i].pods = 0;

--- a/test/foundry/sun/Cases.t.sol
+++ b/test/foundry/sun/Cases.t.sol
@@ -375,7 +375,7 @@ contract CasesTest is TestHelper {
         deltaPodDemandCase = caseId % 3;
     }
 
-    function `(
+    function calcMinSoilDemandThreshold(
         uint256 beanSupply,
         uint256 initialSoil
     ) internal view returns (uint256 minDemandThreshold) {

--- a/test/foundry/sun/Cases.t.sol
+++ b/test/foundry/sun/Cases.t.sol
@@ -311,7 +311,7 @@ contract CasesTest is TestHelper {
         deal(address(bean), address(1), beanSupply);
         beanSupply = bean.totalSupply();
         // bound initial soil to 0 - beanSupply
-        initialSoil = bound(initialSoil, 0, beanSupply);
+        initialSoil = bound(initialSoil, 4, beanSupply);
 
         uint256 minDemandThreshold = calcMinSoilDemandThreshold(beanSupply, initialSoil);
 
@@ -375,7 +375,7 @@ contract CasesTest is TestHelper {
         deltaPodDemandCase = caseId % 3;
     }
 
-    function calcMinSoilDemandThreshold(
+    function `(
         uint256 beanSupply,
         uint256 initialSoil
     ) internal view returns (uint256 minDemandThreshold) {
@@ -387,7 +387,7 @@ contract CasesTest is TestHelper {
         // scale s.sys.initialSoil by the initialSoilPodDemandScalar, currently 25%.
         uint256 scaledInitialSoil = (initialSoil * 0.25e6) / 1e6;
 
-        minDemandThreshold = beanSupplyThreshold > scaledInitialSoil
+        minDemandThreshold = beanSupplyThreshold < scaledInitialSoil
             ? beanSupplyThreshold
             : scaledInitialSoil;
     }

--- a/test/hardhat/Field.test.js
+++ b/test/hardhat/Field.test.js
@@ -355,34 +355,25 @@ describe("newField", function () {
   });
 
   describe("complex DPD", async function () {
-    it("Does not set thisSowTime if Soil > 1", async function () {
-      await mockBeanstalk.setSoilE(to6("3"));
+    it("Does not set thisSowTime if Soil > sold_out_threshold", async function () {
+      await mockBeanstalk.setSoilE(to6("10000"));
       await beanstalk.connect(user).sow(to6("1"), 0, EXTERNAL);
       const weather = await beanstalk.weather();
       expect(weather.thisSowTime).to.be.equal(parseInt(MAX_UINT32));
     });
 
-    it("Does set thisSowTime if Soil = 1", async function () {
-      await mockBeanstalk.setSoilE(to6("1"));
-      await beanstalk.connect(user).sow(to6("1"), 0, EXTERNAL);
+    it("Does set thisSowTime if Soil = sold_out_threshold", async function () {
+      await mockBeanstalk.setSoilE(to6("100"));
+      await beanstalk.connect(user).sow(to6("50"), 0, EXTERNAL);
       const weather = await beanstalk.weather();
       expect(weather.thisSowTime).to.be.not.equal(parseInt(MAX_UINT32));
     });
 
-    it("Does set thisSowTime if Soil < 1", async function () {
-      await mockBeanstalk.setSoilE(to6("1.5"));
-      await beanstalk.connect(user).sow(to6("1"), 0, EXTERNAL);
+    it("Correctly sets thisSowTime if Soil < sold_out_threshold and Initial Soil < 100", async function () {
+      await mockBeanstalk.setSoilE(to6("80"));
+      await beanstalk.connect(user).sow(to6("50"), 0, EXTERNAL); // above 50% of intial soil
       const weather = await beanstalk.weather();
       expect(weather.thisSowTime).to.be.not.equal(parseInt(MAX_UINT32));
-    });
-
-    it("Does not set thisSowTime if Soil already < 1", async function () {
-      await mockBeanstalk.setSoilE(to6("1.5"));
-      await beanstalk.connect(user).sow(to6("1"), 0, EXTERNAL);
-      const weather = await beanstalk.weather();
-      await beanstalk.connect(user).sow(to6("0.5"), 0, EXTERNAL);
-      const weather2 = await beanstalk.weather();
-      expect(weather2.thisSowTime).to.be.equal(weather.thisSowTime);
     });
   });
 


### PR DESCRIPTION
### Update the soil sold out threshold as a function of the soil issued.
- If initialSoil < 100, threshold = initialSoil * 50% --> else, threshold = 50
- Save initial Soil at the start of the season in storage and calculate the threshold dynamically after each sow in `_saveSowTime()`

### Update the minimum soil in which the protocol measures demand to be:
$$
\min\left( \max(Z \cdot \text{supply}, Y ) , X \cdot \text{initialSoil} \right)
$$
- Params: `y=10` , `Z = supplyPodDemandScalar = 0.001%` , `X= initialSoilPodDemandScalar = 25%`
- Add `calcMinSoilDemandThreshold()` to perform the calculation and compare the result in `calcDeltaPodDemand`. Return early with decreasing demand if soil sown is below that threshold.