### PR TITLE
Soil orderbook fix lp withdraw

### DIFF
--- a/abi/ecosystem/SiloHelpers.json
+++ b/abi/ecosystem/SiloHelpers.json
@@ -38,33 +38,6 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint8",
-        "name": "bits",
-        "type": "uint8"
-      },
-      {
-        "internalType": "int256",
-        "name": "value",
-        "type": "int256"
-      }
-    ],
-    "name": "SafeCastOverflowedIntDowncast",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
-      }
-    ],
-    "name": "SafeCastOverflowedUintToInt",
-    "type": "error"
-  },
-  {
     "anonymous": false,
     "inputs": [
       {
@@ -556,6 +529,67 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8[]",
+        "name": "tokenIndices",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "targetAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxGrownStalkPerBdv",
+        "type": "uint256"
+      }
+    ],
+    "name": "getWithdrawalPlan",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address[]",
+            "name": "sourceTokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "int96[][]",
+            "name": "stems",
+            "type": "int96[][]"
+          },
+          {
+            "internalType": "uint256[][]",
+            "name": "amounts",
+            "type": "uint256[][]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "availableBeans",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalAvailableBeans",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SiloHelpers.WithdrawalPlan",
+        "name": "plan",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "a",
         "type": "uint256"
@@ -599,6 +633,25 @@
       }
     ],
     "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "whitelistedOperators",
+        "type": "address[]"
+      }
+    ],
+    "name": "isOperatorWhitelisted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -824,6 +877,44 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "publisher",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tipAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "tipAmount",
+        "type": "int256"
+      },
+      {
+        "internalType": "enum LibTransfer.From",
+        "name": "from",
+        "type": "uint8"
+      },
+      {
+        "internalType": "enum LibTransfer.To",
+        "name": "to",
+        "type": "uint8"
+      }
+    ],
+    "name": "tip",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "newOwner",
         "type": "address"
       }
@@ -855,7 +946,7 @@
       },
       {
         "internalType": "uint8[]",
-        "name": "sourceTokenIndices",
+        "name": "tokenIndices",
         "type": "uint8[]"
       },
       {
@@ -869,9 +960,46 @@
         "type": "uint256"
       },
       {
+        "internalType": "uint256",
+        "name": "slippageRatio",
+        "type": "uint256"
+      },
+      {
         "internalType": "enum LibTransfer.To",
         "name": "mode",
         "type": "uint8"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address[]",
+            "name": "sourceTokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "int96[][]",
+            "name": "stems",
+            "type": "int96[][]"
+          },
+          {
+            "internalType": "uint256[][]",
+            "name": "amounts",
+            "type": "uint256[][]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "availableBeans",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalAvailableBeans",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SiloHelpers.WithdrawalPlan",
+        "name": "plan",
+        "type": "tuple"
       }
     ],
     "name": "withdrawBeansFromSources",

--- a/abi/ecosystem/SowBlueprintv0.json
+++ b/abi/ecosystem/SowBlueprintv0.json
@@ -10,11 +10,6 @@
         "internalType": "address",
         "name": "_siloHelpers",
         "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_priceManipulation",
-        "type": "address"
       }
     ],
     "stateMutability": "nonpayable",
@@ -65,43 +60,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "enum SowBlueprintv0.RewardType",
-        "name": "rewardType",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "publisher",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "operator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "int256",
-        "name": "amount",
-        "type": "int256"
-      }
-    ],
-    "name": "OperatorReward",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
@@ -144,12 +102,12 @@
         "type": "bytes32"
       }
     ],
-    "name": "getCounter",
+    "name": "getLastExecutedSeason",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint32",
         "name": "",
-        "type": "uint256"
+        "type": "uint32"
       }
     ],
     "stateMutability": "view",
@@ -159,16 +117,16 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "blueprintHash",
+        "name": "orderHash",
         "type": "bytes32"
       }
     ],
-    "name": "getLastExecutedSeason",
+    "name": "getPintosLeftToSow",
     "outputs": [
       {
-        "internalType": "uint32",
+        "internalType": "uint256",
         "name": "",
-        "type": "uint32"
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -259,6 +217,11 @@
                 "internalType": "uint256",
                 "name": "runBlocksAfterSunrise",
                 "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "slippageRatio",
+                "type": "uint256"
               }
             ],
             "internalType": "struct SowBlueprintv0.SowParams",
@@ -322,6 +285,287 @@
     "name": "unpauseFunction",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint8[]",
+                "name": "sourceTokenIndices",
+                "type": "uint8[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint256",
+                    "name": "totalAmountToSow",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "minAmountToSowPerSeason",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "maxAmountToSowPerSeason",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct SowBlueprintv0.SowAmounts",
+                "name": "sowAmounts",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "minTemp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxPodlineLength",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxGrownStalkPerBdv",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "runBlocksAfterSunrise",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "slippageRatio",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct SowBlueprintv0.SowParams",
+            "name": "sowParams",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address[]",
+                "name": "whitelistedOperators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "address",
+                "name": "tipAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "int256",
+                "name": "operatorTipAmount",
+                "type": "int256"
+              }
+            ],
+            "internalType": "struct SowBlueprintv0.OperatorParams",
+            "name": "opParams",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct SowBlueprintv0.SowBlueprintStruct",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "blueprintPublisher",
+        "type": "address"
+      }
+    ],
+    "name": "validateParamsAndReturnBeanstalkState",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "availableSoil",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "beanToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "currentSeason",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pintoLeftToSow",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalAmountToSow",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalBeansNeeded",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address[]",
+            "name": "sourceTokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "int96[][]",
+            "name": "stems",
+            "type": "int96[][]"
+          },
+          {
+            "internalType": "uint256[][]",
+            "name": "amounts",
+            "type": "uint256[][]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "availableBeans",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalAvailableBeans",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SiloHelpers.WithdrawalPlan",
+        "name": "plan",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint8[]",
+                "name": "sourceTokenIndices",
+                "type": "uint8[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint256",
+                    "name": "totalAmountToSow",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "minAmountToSowPerSeason",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "maxAmountToSowPerSeason",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct SowBlueprintv0.SowAmounts",
+                "name": "sowAmounts",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint256",
+                "name": "minTemp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxPodlineLength",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxGrownStalkPerBdv",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "runBlocksAfterSunrise",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "slippageRatio",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct SowBlueprintv0.SowParams",
+            "name": "sowParams",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address[]",
+                "name": "whitelistedOperators",
+                "type": "address[]"
+              },
+              {
+                "internalType": "address",
+                "name": "tipAddress",
+                "type": "address"
+              },
+              {
+                "internalType": "int256",
+                "name": "operatorTipAmount",
+                "type": "int256"
+              }
+            ],
+            "internalType": "struct SowBlueprintv0.OperatorParams",
+            "name": "opParams",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct SowBlueprintv0.SowBlueprintStruct[]",
+        "name": "paramsArray",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "orderHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "blueprintPublishers",
+        "type": "address[]"
+      }
+    ],
+    "name": "validateParamsAndReturnBeanstalkStateArray",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "validOrderHashes",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/contracts/ecosystem/SiloHelpers.sol
+++ b/contracts/ecosystem/SiloHelpers.sol
@@ -292,35 +292,45 @@ contract SiloHelpers is Junction, PerFunctionPausable {
                     LibTransfer.To.INTERNAL
                 );
 
+                // Calculate total amount of LP tokens to transfer
+                uint256 totalLPAmount = 0;
+                for (uint256 j = 0; j < plan.amounts[i].length; j++) {
+                    totalLPAmount += plan.amounts[i][j];
+                }
+
                 // Transfer LP tokens to this contract's external balance
                 beanstalk.transferInternalTokenFrom(
                     IERC20(sourceToken),
                     account,
                     address(this),
-                    plan.amounts[i][0], // Use first amount since it's the total LP amount
+                    totalLPAmount, // Use the total sum of all amounts
                     LibTransfer.To.EXTERNAL
                 );
 
                 // Then remove liquidity to get Beans
-                IERC20(sourceToken).approve(sourceToken, plan.amounts[i][0]);
-                uint256 beansOut = IWell(sourceToken).removeLiquidityOneToken(
-                    plan.amounts[i][0],
+                IERC20(sourceToken).approve(sourceToken, totalLPAmount);
+                IWell(sourceToken).removeLiquidityOneToken(
+                    totalLPAmount,
                     IERC20(beanToken),
-                    plan.availableBeans[i], // Min amount out should be the remaining amount needed
+                    plan.availableBeans[i],
                     address(this),
                     type(uint256).max
                 );
 
                 // approve spending of Beans from this contract's external balance
-                IERC20(beanToken).approve(address(beanstalk), beansOut);
+                IERC20(beanToken).approve(address(beanstalk), plan.availableBeans[i]);
 
                 // Transfer from this contract's external balance to the user's internal/external balance depending on mode
                 if (mode == LibTransfer.To.INTERNAL) {
-                    beanstalk.sendTokenToInternalBalance(beanToken, account, beansOut);
+                    beanstalk.sendTokenToInternalBalance(
+                        beanToken,
+                        account,
+                        plan.availableBeans[i]
+                    );
                 } else {
-                    IERC20(beanToken).transfer(account, beansOut);
+                    IERC20(beanToken).transfer(account, plan.availableBeans[i]);
                 }
-                amountWithdrawn += beansOut;
+                amountWithdrawn += plan.availableBeans[i];
             }
         }
 

--- a/test/foundry/ecosystem/SiloHelpers.t.sol
+++ b/test/foundry/ecosystem/SiloHelpers.t.sol
@@ -243,6 +243,47 @@ contract SiloHelpersTest is TractorHelper {
         }
     }
 
+    function test_withdrawBeansHelperMultipleLPDeposits() public {
+        // Setup: Create multiple LP deposits over various seasons, deposit amounts 100, then 200, then 300, etc
+        uint256 numDeposits = 10;
+        uint256 depositAmount = 100e6;
+        uint256 totalBeansToWithdraw = 0;
+        for (uint256 i = 1; i < numDeposits + 1; i++) {
+            mintAndDepositBeanETH(farmers[0], depositAmount * i);
+            totalBeansToWithdraw += depositAmount * i;
+        }
+
+        // Get all deposits to find grown stalk values
+        (int96[] memory allStems, uint256[] memory allAmounts) = siloHelpers.getSortedDeposits(
+            farmers[0],
+            BEAN_ETH_WELL
+        );
+
+        uint256 initialBeanBalance = IERC20(BEAN).balanceOf(farmers[0]);
+
+        // Setup a setupWithdrawBeansBlueprint to withdraw the total amount of beans
+        uint8[] memory sourceTokenIndices = new uint8[](1);
+        sourceTokenIndices[0] = siloHelpers.getTokenIndex(BEAN_ETH_WELL);
+        IMockFBeanstalk.Requisition memory req = setupWithdrawBeansBlueprint(
+            farmers[0],
+            totalBeansToWithdraw,
+            sourceTokenIndices,
+            MAX_GROWN_STALK_PER_BDV,
+            LibTransfer.To.EXTERNAL
+        );
+
+        // Execute the blueprint
+        vm.prank(farmers[0]);
+        bs.publishRequisition(req);
+        executeRequisition(farmers[0], req, address(bs));
+
+        assertEq(
+            IERC20(BEAN).balanceOf(farmers[0]),
+            initialBeanBalance + totalBeansToWithdraw,
+            "Bean balance incorrect after withdrawal"
+        );
+    }
+
     function test_withdrawBeansHelper() public {
         // Setup: Create deposits in both Bean and LP tokens
         uint256 beanAmount = 1000e6;

--- a/test/foundry/utils/TestHelper.sol
+++ b/test/foundry/utils/TestHelper.sol
@@ -170,6 +170,42 @@ contract TestHelper is
         MockToken(token).approve(BEANSTALK, type(uint256).max);
     }
 
+    function mintAndDepositBeanETH(address user, uint256 amountInBeans) public {
+        // We assume bean:eth is 1000:1 here, where it's 1000e6 and 1e18
+        uint256 amountInWETH = amountInBeans * 1e12;
+        mintTokensToUser(user, WETH, amountInWETH);
+        mintTokensToUser(user, BEAN, amountInBeans);
+
+        // Approve spending Bean to well
+        vm.prank(user);
+        MockToken(BEAN).approve(BEAN_ETH_WELL, amountInBeans);
+
+        // Approve spending WETH to well
+        vm.prank(user);
+        MockToken(WETH).approve(BEAN_ETH_WELL, amountInWETH);
+
+        // Deposit LP tokens
+        uint256[] memory tokenAmountsIn = new uint256[](2);
+        tokenAmountsIn[0] = amountInBeans;
+        tokenAmountsIn[1] = amountInWETH;
+
+        // Approve spending LP tokens to Beanstalk
+        vm.prank(user);
+        MockToken(BEAN_ETH_WELL).approve(address(bs), type(uint256).max);
+
+        vm.prank(user);
+        uint256 lpAmountOut = IWell(BEAN_ETH_WELL).addLiquidity(
+            tokenAmountsIn,
+            0,
+            user,
+            type(uint256).max
+        );
+
+        vm.prank(user);
+        bs.deposit(BEAN_ETH_WELL, lpAmountOut, 0);
+        bs.siloSunrise(0);
+    }
+
     function addLiquidityToWell(
         address well,
         uint256 beanAmount,


### PR DESCRIPTION
Fixes issue where [0] was used for LP withdraw amounts, instead of the proper amount.