### PR TITLE
Soil orderbook reduce contract size

### DIFF
--- a/contracts/ecosystem/TractorHelpers.sol
+++ b/contracts/ecosystem/TractorHelpers.sol
@@ -931,41 +931,7 @@ contract TractorHelpers is Junction, PerFunctionPausable {
     function isOperatorWhitelisted(
         address[] calldata whitelistedOperators
     ) external view returns (bool) {
-        // If there are no whitelisted operators, pass in, accept any operator
-        if (whitelistedOperators.length == 0) {
-            return true;
-        }
-
-        address currentOperator = beanstalk.operator();
-        for (uint256 i = 0; i < whitelistedOperators.length; i++) {
-            address checkAddress = whitelistedOperators[i];
-            if (checkAddress == currentOperator) {
-                return true;
-            } else {
-                // Skip if address is a precompiled contract (address < 0x20)
-                if (uint160(checkAddress) <= 0x20) continue;
-
-                // Check if the address is a contract before attempting staticcall
-                uint256 size;
-                assembly {
-                    size := extcodesize(checkAddress)
-                }
-
-                if (size > 0) {
-                    try
-                        IOperatorWhitelist(checkAddress).checkOperatorWhitelist(currentOperator)
-                    returns (bool success) {
-                        if (success) {
-                            return true;
-                        }
-                    } catch {
-                        // If the call fails, continue to the next address
-                        continue;
-                    }
-                }
-            }
-        }
-        return false;
+        return LibTractorHelpers.isOperatorWhitelisted(whitelistedOperators, beanstalk);
     }
 
     /**

--- a/contracts/ecosystem/TractorHelpers.sol
+++ b/contracts/ecosystem/TractorHelpers.sol
@@ -883,38 +883,14 @@ contract TractorHelpers is Junction, PerFunctionPausable {
         address[] memory tokens,
         uint256[] memory index
     ) internal pure returns (address[] memory, uint256[] memory) {
-        for (uint256 i = 0; i < tokens.length - 1; i++) {
-            for (uint256 j = 0; j < tokens.length - i - 1; j++) {
-                uint256 j1 = j + 1;
-                if (index[j] < index[j1]) {
-                    // Swap index
-                    (index[j], index[j1]) = (index[j1], index[j]);
-
-                    // Swap corresponding tokens
-                    (tokens[j], tokens[j1]) = (tokens[j1], tokens[j]);
-                }
-            }
-        }
-        return (tokens, index);
+        return LibTractorHelpers.sortTokens(tokens, index);
     }
 
     function sortTokenIndices(
         uint8[] memory tokenIndices,
         uint256[] memory index
     ) internal pure returns (uint8[] memory, uint256[] memory) {
-        for (uint256 i = 0; i < tokenIndices.length - 1; i++) {
-            for (uint256 j = 0; j < tokenIndices.length - i - 1; j++) {
-                uint256 j1 = j + 1;
-                if (index[j] > index[j1]) {
-                    // Swap index
-                    (index[j], index[j1]) = (index[j1], index[j]);
-
-                    // Swap token indices
-                    (tokenIndices[j], tokenIndices[j1]) = (tokenIndices[j1], tokenIndices[j]);
-                }
-            }
-        }
-        return (tokenIndices, index);
+        return LibTractorHelpers.sortTokenIndices(tokenIndices, index);
     }
 
     /**

--- a/contracts/ecosystem/price/WellPrice.sol
+++ b/contracts/ecosystem/price/WellPrice.sol
@@ -54,9 +54,17 @@ contract WellPrice {
     }
 
     /**
-     * @notice Returns the non-manipulation resistant on-chain liquidiy, deltaB and price data for
+     * @notice Returns the non-manipulation resistant on-chain liquidity, deltaB and price data for
      * Bean in a given Well.
      * @dev No protocol should use this function to calculate manipulation resistant Bean price data.
+     **/
+    function getWell(address wellAddress) public view returns (P.Pool memory) {
+        return getWell(wellAddress, ReservesType.CURRENT_RESERVES);
+    }
+
+    /**
+     * @notice Returns the on-chain liquidity according to the passed in reservesType, deltaB and price data for
+     * Bean in a given Well.
      **/
     function getWell(
         address wellAddress,

--- a/contracts/libraries/Silo/LibTractorHelpers.sol
+++ b/contracts/libraries/Silo/LibTractorHelpers.sol
@@ -178,4 +178,42 @@ library LibTractorHelpers {
 
         return combinedPlan;
     }
+
+    function sortTokens(
+        address[] memory tokens,
+        uint256[] memory index
+    ) external pure returns (address[] memory, uint256[] memory) {
+        for (uint256 i = 0; i < tokens.length - 1; i++) {
+            for (uint256 j = 0; j < tokens.length - i - 1; j++) {
+                uint256 j1 = j + 1;
+                if (index[j] < index[j1]) {
+                    // Swap index
+                    (index[j], index[j1]) = (index[j1], index[j]);
+
+                    // Swap corresponding tokens
+                    (tokens[j], tokens[j1]) = (tokens[j1], tokens[j]);
+                }
+            }
+        }
+        return (tokens, index);
+    }
+
+    function sortTokenIndices(
+        uint8[] memory tokenIndices,
+        uint256[] memory index
+    ) external pure returns (uint8[] memory, uint256[] memory) {
+        for (uint256 i = 0; i < tokenIndices.length - 1; i++) {
+            for (uint256 j = 0; j < tokenIndices.length - i - 1; j++) {
+                uint256 j1 = j + 1;
+                if (index[j] > index[j1]) {
+                    // Swap index
+                    (index[j], index[j1]) = (index[j1], index[j]);
+
+                    // Swap token indices
+                    (tokenIndices[j], tokenIndices[j1]) = (tokenIndices[j1], tokenIndices[j]);
+                }
+            }
+        }
+        return (tokenIndices, index);
+    }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -728,7 +728,6 @@ task("PI-8", "Deploys Pinto improvment set 8, Tractor, Soil Orderbook").setActio
     const sowBlueprint = await ethers.getContractFactory("SowBlueprintv0");
     const sowBlueprintContract = await sowBlueprint.deploy(
       L2_PINTO, // diamond address
-      beanstalkPriceContract.address, // price contract
       L2_PCM, // owner address
       tractorHelpersContract.address // tractorHelpers contract address
     );
@@ -741,7 +740,7 @@ task("PI-8", "Deploys Pinto improvment set 8, Tractor, Soil Orderbook").setActio
     console.log("\nStarting diamond upgrade...");
 
     /////////////////////// Diamond Upgrade ///////////////////////
-    
+
     await upgradeWithNewFacets({
       diamondAddress: L2_PINTO,
       facetNames: [
@@ -839,7 +838,6 @@ task("TractorHelpers", "Deploys TractorHelpers").setAction(async function () {
   const sowBlueprint = await ethers.getContractFactory("SowBlueprintv0");
   const sowBlueprintContract = await sowBlueprint.deploy(
     L2_PINTO,
-    "0xD0fd333F7B30c7925DEBD81B7b7a4DFE106c3a5E", // price contract
     await owner.getAddress(), // owner address
     tractorHelpersContract.address // tractorHelpers contract address
   );

--- a/test/hardhat/beanstalkPrice.test.js
+++ b/test/hardhat/beanstalkPrice.test.js
@@ -59,7 +59,7 @@ describe("BeanstalkPrice", function () {
 
   describe("Price", async function () {
     it("deltaB = 0", async function () {
-      const p = await this.beanstalkPrice.price();
+      const p = await this.beanstalkPrice["price()"]();
       // price is within +/- 1 due to rounding
       expect(p.price).to.equal("999999");
       expect(p.liquidity).to.equal("3999998000000");
@@ -75,8 +75,8 @@ describe("BeanstalkPrice", function () {
         value: 0
       });
 
-      const p = await this.beanstalkPrice.price();
-      const w = await this.beanstalkPrice.getWell(BEAN_ETH_WELL);
+      const p = await this.beanstalkPrice["price()"]();
+      const w = await this.beanstalkPrice["getWell(address)"](BEAN_ETH_WELL);
 
       expect(p.price).to.equal("1499997");
       expect(p.liquidity).to.equal("3999997000000");
@@ -96,8 +96,8 @@ describe("BeanstalkPrice", function () {
         value: 0
       });
 
-      const p = await this.beanstalkPrice.price();
-      const w = await this.beanstalkPrice.getWell(BEAN_ETH_WELL);
+      const p = await this.beanstalkPrice["price()"]();
+      const w = await this.beanstalkPrice["getWell(address)"](BEAN_ETH_WELL);
 
       expect(p.price).to.equal("749999");
       expect(p.liquidity).to.equal("3999997000000");


### PR DESCRIPTION
Currently too large to deploy, this fixes that by moving things to the library