### PR TITLE
PI-9

### DIFF
--- a/contracts/libraries/Silo/LibSilo.sol
+++ b/contracts/libraries/Silo/LibSilo.sol
@@ -763,6 +763,10 @@ library LibSilo {
         uint256[] calldata sortedDepositIds
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        // Update the idIndex for each deposit ID
+        for (uint256 i = 0; i < sortedDepositIds.length; i++) {
+            s.accts[account].depositIdList[token].idIndex[sortedDepositIds[i]] = i;
+        }
         s.accts[account].depositIdList[token].depositIds = sortedDepositIds;
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -801,6 +801,39 @@ task("PI-8", "Deploys Pinto improvment set 8, Tractor, Soil Orderbook").setActio
   }
 );
 
+task("silo-tractor-fix", "Deploys silo tractor fix").setAction(async function () {
+  const mock = true;
+  let owner;
+  if (mock) {
+    owner = await impersonateSigner(L2_PCM);
+    await mintEth(owner.address);
+  } else {
+    owner = (await ethers.getSigners())[0];
+  }
+  // upgrade facets
+  await upgradeWithNewFacets({
+    diamondAddress: L2_PINTO,
+    facetNames: [
+      "ApprovalFacet",
+      "ClaimFacet",
+      "ConvertFacet",
+      "PipelineConvertFacet",
+      "SiloFacet",
+      "SiloGettersFacet"
+    ],
+    libraryNames: ["LibSilo", "LibTokenSilo", "LibConvert", "LibPipelineConvert"],
+    facetLibraries: {
+      ClaimFacet: ["LibSilo", "LibTokenSilo"],
+      ConvertFacet: ["LibConvert", "LibPipelineConvert", "LibSilo", "LibTokenSilo"],
+      PipelineConvertFacet: ["LibPipelineConvert", "LibSilo", "LibTokenSilo"],
+      SiloFacet: ["LibSilo", "LibTokenSilo"]
+    },
+    object: !mock,
+    verbose: true,
+    account: owner
+  });
+});
+
 task("getWhitelistedWells", "Lists all whitelisted wells and their non-pinto tokens").setAction(
   async () => {
     console.log("-----------------------------------");

--- a/test/foundry/silo/Silo.t.sol
+++ b/test/foundry/silo/Silo.t.sol
@@ -309,6 +309,32 @@ contract SiloTest is TestHelper {
             unsortedDepositIds[swapIndex]
         );
 
+        // verify the idIndex is updated correctly
+        for (uint256 i; i < numDeposits; i++) {
+            assertEq(bs.getIndexForDepositId(farmers[0], BEAN, newDepositIds[i]), i);
+        }
+
+        uint256 snapshot = vm.snapshot();
+        {
+            IMockFBeanstalk.TokenDepositId memory deposit = bs.getTokenDepositsForAccount(
+                farmers[0],
+                BEAN
+            );
+            // verify a user can withdraw all deposits
+
+            vm.prank(farmers[0]);
+            int96[] memory stems = new int96[](numDeposits);
+            uint256[] memory amounts = new uint256[](numDeposits);
+            for (uint256 i; i < numDeposits; i++) {
+                (address token, int96 stem) = LibBytes.unpackAddressAndStem(deposit.depositIds[i]);
+                stems[i] = stem;
+                amounts[i] = deposit.tokenDeposits[i].amount;
+            }
+            bs.withdrawDeposits(BEAN, stems, amounts, 0);
+        }
+
+        vm.revertTo(snapshot);
+
         // Verify that updating with unsorted IDs reverts
         vm.prank(farmers[0]);
         vm.expectRevert("Deposit IDs not sorted");


### PR DESCRIPTION
# PI-9: Helper Function Bug Fix

Committed on April 18, 2025.

## Summary

Update the `_setSortedDepositIds` function to properly set the Deposited IDs.

## Links

* [PI-9 GitHub PR](https://github.com/pinto-org/protocol/pull/77)
* [Safe Transaction](https://app.safe.global/transactions/tx?safe=base:0x2cf82605402912C6a79078a9BBfcCf061CbfD507&id=multisig_0x2cf82605402912C6a79078a9BBfcCf061CbfD507_0x616f091ed00ade24e93c084e4baea1fc2d129d81113d94fc87eda017745c5d96)
* [BaseScan Transaction](https://basescan.org/tx/0xe3f532ddf06b5a70bd8c1be8a2f3c54e3ec2de18aa16a3d1e4d1f2bdd9c208c9)

## Problem

The protocol stores a list of a Farmers' Deposits onchain, which is used to allow clients like the Pinto UI to easily query data Deposit data. The protocol also stores a mapping of Deposit IDs to index in order to efficiently look up a Deposit. [PI-8](https://github.com/pinto-org/protocol/pull/47) introduced a `updateSortedDepositIds` function that allows anyone to sort this Deposit list in ascending order. This did not properly update the mapping to reflect this. 

No funds were ever at risk as a result of this issue.

## Solution

Update `LibSilo._setSortedDepositIds` to properly update the mapping based on the new ordering.

## Contract Changes

### ApprovalFacet

The following `ApprovalFacet` was removed from Pinto:

* [`0x65d67f299A4Ad1CfF49a6C77A2Fb463A86643Ab4`](https://basescan.org/address/0x65d67f299A4Ad1CfF49a6C77A2Fb463A86643Ab4#code)

The following `ApprovalFacet` was added to Pinto:

* [`0xa7c95ED70be8F91f8D8aF91dE193710Fa7Ab32bb`](https://basescan.org/address/0xa7c95ED70be8F91f8D8aF91dE193710Fa7Ab32bb#code)

### ClaimFacet

The following `ClaimFacet` was removed from Pinto:

* [`0x8738F66d4a0431B084b7fF8f59097312A5B5531F`](https://basescan.org/address/0x8738F66d4a0431B084b7fF8f59097312A5B5531F#code)

The following `ClaimFacet` was added to Pinto:

* [`0xd38c3E61bF08734cD808aCA15C944389968612e0`](https://basescan.org/address/0xd38c3E61bF08734cD808aCA15C944389968612e0#code)

### ConvertFacet

The following `ConvertFacet` was removed from Pinto:

* [`0x1Af9097b043E26F41D082C5adb89Cd606528e526`](https://basescan.org/address/0x1Af9097b043E26F41D082C5adb89Cd606528e526#code)

The following `ConvertFacet` was added to Pinto:

* [`0xdFa197784879926e2358A7C71C6A0BD487F919FD`](https://basescan.org/address/0xdFa197784879926e2358A7C71C6A0BD487F919FD#code)

### PipelineConvertFacet

The following `PipelineConvertFacet` was removed from Pinto:

* [`0xc54Cd71Bfa5D0FE05D887EaBBEC4DbbC94CF74Ba`](https://basescan.org/address/0xc54Cd71Bfa5D0FE05D887EaBBEC4DbbC94CF74Ba#code)

The following `PipelineConvertFacet` was added to Pinto:

* [`0xf26ab0c4a354f12c9e8FA86C423F463E2c72DDd8`](https://basescan.org/address/0xf26ab0c4a354f12c9e8FA86C423F463E2c72DDd8#code)

### SiloFacet

The following `SiloFacet` was removed from Pinto:

* [`0xD954A3245A868ab3e991786d4E5E71892099a19d`](https://basescan.org/address/0xD954A3245A868ab3e991786d4E5E71892099a19d#code)

The following `SiloFacet` was added to Pinto:

* [`0xF6aF001b8879A2E30DB294B4C8deccbD0D168b34`](https://basescan.org/address/0xF6aF001b8879A2E30DB294B4C8deccbD0D168b34#code)

### SiloGettersFacet

The following `SiloGettersFacet` was removed from Pinto:

* [`0x6F9a49560A1Db78cd32f1332E15fCAeDC77aA66B`](https://basescan.org/address/0x6F9a49560A1Db78cd32f1332E15fCAeDC77aA66B#code)

The following `SiloGettersFacet` was added to Pinto:

* [`0xadFd7FbE59CA2624cec1B04F9bc65C7f90EFEd36`](https://basescan.org/address/0xadFd7FbE59CA2624cec1B04F9bc65C7f90EFEd36#code)
