### PR TITLE
PDV capacity ramp

### DIFF
--- a/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
+++ b/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
@@ -204,11 +204,13 @@ contract ConvertGettersFacet {
         uint256 bonusStalkPerBdv = (gv.baseBonusStalkPerBdv * gv.convertCapacityFactor) /
             C.PRECISION;
 
-        if (gd.thisSeasonBdvConverted >= gv.maxConvertCapacity) {
+        uint256 convertCapacity = LibConvert.getConvertCapacity(gv.maxConvertCapacity);
+
+        if (gd.thisSeasonBdvConverted >= convertCapacity) {
             return (bonusStalkPerBdv, 0);
         }
 
-        return (bonusStalkPerBdv, gv.maxConvertCapacity - gd.thisSeasonBdvConverted);
+        return (bonusStalkPerBdv, convertCapacity - gd.thisSeasonBdvConverted);
     }
 
     /**

--- a/contracts/beanstalk/facets/sun/GaugeFacet.sol
+++ b/contracts/beanstalk/facets/sun/GaugeFacet.sol
@@ -15,6 +15,11 @@ import {Gauge, GaugeId} from "contracts/beanstalk/storage/System.sol";
 import {PRBMathUD60x18} from "@prb/math/contracts/PRBMathUD60x18.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {LibConvert} from "contracts/libraries/Convert/LibConvert.sol";
+import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedTokens.sol";
+import {LibWellMinting} from "contracts/libraries/Minting/LibWellMinting.sol";
+import {LibMinting} from "contracts/libraries/Minting/LibMinting.sol";
+import {BeanstalkERC20} from "contracts/tokens/ERC20/BeanstalkERC20.sol";
+
 /**
  * @title GaugeFacet
  * @notice Calculates the gaugePoints for whitelisted Silo LP tokens.

--- a/contracts/beanstalk/facets/sun/GaugeFacet.sol
+++ b/contracts/beanstalk/facets/sun/GaugeFacet.sol
@@ -19,6 +19,7 @@ import {LibWhitelistedTokens} from "contracts/libraries/Silo/LibWhitelistedToken
 import {LibWellMinting} from "contracts/libraries/Minting/LibWellMinting.sol";
 import {LibMinting} from "contracts/libraries/Minting/LibMinting.sol";
 import {BeanstalkERC20} from "contracts/tokens/ERC20/BeanstalkERC20.sol";
+import "forge-std/console.sol";
 
 /**
  * @title GaugeFacet
@@ -180,7 +181,7 @@ contract GaugeFacet is GaugeDefault, ReentrancyGuard {
 
     /**
      * @notice Calculates the stalk per pdv the protocol is willing to issue along with the
-     * correspoinding pdv capacity.
+     * corresponding pdv capacity.
      * ----------------------------------------------------------------
      * @return value
      *  The gauge value is encoded as (uint256, uint256, uint256, uint256):

--- a/contracts/interfaces/IMockFBeanstalk.sol
+++ b/contracts/interfaces/IMockFBeanstalk.sol
@@ -220,6 +220,7 @@ interface IMockFBeanstalk {
         bool raining;
         uint64 sunriseBlock;
         bool abovePeg;
+        uint32 pegCrossSeason;
         uint256 start;
         uint256 period;
         uint256 timestamp;
@@ -1913,4 +1914,9 @@ interface IMockFBeanstalk {
     ) external;
 
     function setSeasonAbovePeg(bool abovePeg) external;
+
+    function getConvertStalkPerBdvBonusAndRemainingCapacity()
+        external
+        view
+        returns (uint256 bonusStalkPerBdv, uint256 remainingCapacity);
 }

--- a/contracts/libraries/Convert/LibConvert.sol
+++ b/contracts/libraries/Convert/LibConvert.sol
@@ -41,6 +41,10 @@ library LibConvert {
     uint256 internal constant ZERO_STALK_SLIPPAGE = 0;
     uint256 internal constant MAX_GROWN_STALK_SLIPPAGE = 1e18;
 
+    uint256 internal constant PRECISION = 1e18;
+    uint256 internal constant INITIAL_CAPACITY = 0.1e18; // 10% of the total capacity
+    uint256 internal constant CAPACITY_RATE = 0.75e18; // hits 100% total capacity 75% into the season
+
     event ConvertDownPenalty(address account, uint256 grownStalkLost);
     event ConvertUpBonus(address account, uint256 grownStalkGained, uint256 bdvCapacityUsed);
 
@@ -641,7 +645,7 @@ library LibConvert {
             (uint256 bdvCapacityUsed, uint256 grownStalkGained) = stalkBonus(toBdv);
 
             // update how much bdv was converted this season.
-            updateBdvConverted(toBdv);
+            updateBdvConverted(toBdv, bdvCapacityUsed);
             if (bdvCapacityUsed > 0) {
                 // update the grown stalk by the amount of grown stalk gained
                 newGrownStalk = grownStalk + grownStalkGained;
@@ -758,22 +762,50 @@ library LibConvert {
             (LibGaugeHelpers.ConvertBonusGaugeData)
         );
 
+        uint256 convertCapacity = getConvertCapacity(gv.maxConvertCapacity);
         // if the max convert capacity has been reached, return 0
-        if (gd.thisSeasonBdvConverted >= gv.maxConvertCapacity) {
+        if (gd.thisSeasonBdvConvertedBonus >= convertCapacity) {
             return (0, 0);
         }
 
         // limit the bdv that can get the bonus
-        uint256 remainingCapacity = gv.maxConvertCapacity - gd.thisSeasonBdvConverted;
+        uint256 remainingCapacity = convertCapacity - gd.thisSeasonBdvConvertedBonus;
         uint256 bdvWithBonus = min(toBdv, remainingCapacity);
 
         // Then calculate the bonus stalk based on the limited BDV
-        uint256 bonusStalkPerBdv = (gv.baseBonusStalkPerBdv * gv.convertBonusFactor) / C.PRECISION;
-        grownStalkGained = (bdvWithBonus * bonusStalkPerBdv);
+        // bonus stalk per bdv = gv.baseBonusStalkPerBdv * gv.convertBonusFactor
+        // bonusStalkPerBdv * BdvWithBonus = GrownStalkGained.
+        grownStalkGained =
+            (bdvWithBonus * gv.baseBonusStalkPerBdv * gv.convertBonusFactor) /
+            C.PRECISION;
 
         return (bdvWithBonus, grownStalkGained);
     }
 
+    /**
+     * @notice Gets the time weighted convert capacity for the current season
+     * @dev the amount of bdv that can be converted with a bonus ramps up linearly over the course of the season,
+     * allowing converts to be more efficent and have a lower slippage.
+     * the initial capacity starts at 10% of the max capacity and ramps up linearly to 100% of the max capacity at 75% of the season.
+     */
+    function getConvertCapacity(uint256 maxConvertCapacity) internal view returns (uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        uint256 convertRampPeriod = (s.sys.season.period * CAPACITY_RATE) / C.PRECISION;
+        uint256 timeElapsed = block.timestamp - s.sys.season.timestamp;
+        // if the current season is past the ramp period, return the max convert capacity
+        if (timeElapsed > convertRampPeriod) {
+            return maxConvertCapacity;
+        } else {
+            // Initial capacity starts at 10% of max capacity
+            // Formula: initialCapacity + (maxCapacity - initialCapacity) * timeElapsed / rampPeriod
+            uint256 initialCapacity = (maxConvertCapacity * INITIAL_CAPACITY) / C.PRECISION; // 10% of max capacity
+            return
+                initialCapacity +
+                ((maxConvertCapacity - initialCapacity) * timeElapsed) /
+                convertRampPeriod;
+        }
+    }
     /**
      * @notice Gets the bonus stalk per bdv for the current season.
      * @dev The stalkPerPDV is determined by taking the difference between the current stem tip
@@ -799,9 +831,10 @@ library LibConvert {
     /**
      * @notice Updates the convert bonus bdv capacity in the convert bonus gauge data.
      * @dev Separated here to allow `stalkBonus` to be called as a getter without touching state.
-     * @param bdvConverted The amount of bdv that got the bonus.
+     * @param bdvConverted The amount of bdv that was converted.
+     * @param bdvConvertedBonus The amount of bdv that was converted with a bonus.
      */
-    function updateBdvConverted(uint256 bdvConverted) internal {
+    function updateBdvConverted(uint256 bdvConverted, uint256 bdvConvertedBonus) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // Get current gauge data using the new struct
@@ -812,7 +845,7 @@ library LibConvert {
 
         // Update this season's converted amount
         gd.thisSeasonBdvConverted += bdvConverted;
-
+        gd.thisSeasonBdvConvertedBonus += bdvConvertedBonus;
         // Encode and store updated gauge data
         LibGaugeHelpers.updateGaugeData(GaugeId.CONVERT_UP_BONUS, abi.encode(gd));
     }

--- a/contracts/libraries/Convert/LibConvert.sol
+++ b/contracts/libraries/Convert/LibConvert.sol
@@ -785,7 +785,7 @@ library LibConvert {
     /**
      * @notice Gets the time weighted convert capacity for the current season
      * @dev the amount of bdv that can be converted with a bonus ramps up linearly over the course of the season,
-     * allowing converts to be more efficent and have a lower slippage.
+     * allowing converts to be more efficient and incur less slippage.
      * the initial capacity starts at 10% of the max capacity and ramps up linearly to 100% of the max capacity at 75% of the season.
      */
     function getConvertCapacity(uint256 maxConvertCapacity) internal view returns (uint256) {

--- a/contracts/libraries/LibGaugeHelpers.sol
+++ b/contracts/libraries/LibGaugeHelpers.sol
@@ -39,6 +39,7 @@ library LibGaugeHelpers {
      * - maxCapacityFactor: The maximum value of the convert bonus bdv capacity factor.
      * - lastSeasonBdvConverted: The amount of bdv converted last season.
      * - thisSeasonBdvConverted: The amount of bdv converted this season.
+     * - thisSeasonBdvConvertedBonus: The amount of bdv converted this season that received a bonus.
      * - deltaBdvConvertedDemandUpperBound: The percentage of bdv converted such that above this value, demand for converting is increasing.
      * - deltaBdvConvertedDemandLowerBound: The percentage of bdv converted such that below this value, demand for converting is decreasing.
      */
@@ -51,6 +52,7 @@ library LibGaugeHelpers {
         uint256 maxCapacityFactor;
         uint256 lastSeasonBdvConverted;
         uint256 thisSeasonBdvConverted;
+        uint256 thisSeasonBdvConvertedBonus;
         uint256 deltaBdvConvertedDemandUpperBound;
         uint256 deltaBdvConvertedDemandLowerBound;
     }

--- a/contracts/libraries/LibInitGauges.sol
+++ b/contracts/libraries/LibInitGauges.sol
@@ -44,7 +44,7 @@ library LibInitGauges {
     uint256 internal constant DELTA_BDV_CONVERTED_DEMAND_LOWER_BOUND = 0.95e18; // the % change in bdv converted between seasons such that demand for converting is decreasing when below this value
     uint256 internal constant LAST_SEASON_BDV_CONVERTED = 0; // the bdv converted in the last season
     uint256 internal constant THIS_SEASON_BDV_CONVERTED = 0; // the bdv converted in the current season
-
+    uint256 internal constant THIS_SEASON_BDV_CONVERTED_BONUS = 0; // the bdv converted in the current season with a bonus
     //////////// Cultivation Factor Gauge ////////////
 
     function initCultivationFactor() internal {
@@ -94,6 +94,7 @@ library LibInitGauges {
             MAX_CAPACITY_FACTOR,
             LAST_SEASON_BDV_CONVERTED,
             THIS_SEASON_BDV_CONVERTED,
+            THIS_SEASON_BDV_CONVERTED_BONUS,
             DELTA_BDV_CONVERTED_DEMAND_UPPER_BOUND,
             DELTA_BDV_CONVERTED_DEMAND_LOWER_BOUND
         );

--- a/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -84,7 +84,7 @@ contract MockConvertFacet is ConvertFacet {
     }
 
     function mockUpdateBdvConverted(uint256 bdvConverted) external {
-        LibConvert.updateBdvConverted(bdvConverted);
+        LibConvert.updateBdvConverted(bdvConverted, bdvConverted);
     }
 
     function mockUpdateBonusBdvCapacity(uint256 newBdvCapacity) external {

--- a/test/foundry/convert/convert.t.sol
+++ b/test/foundry/convert/convert.t.sol
@@ -184,7 +184,7 @@ contract ConvertTest is TestHelper {
 
     /**
      * @notice Bean -> Well convert cannot convert beyond peg.
-     * @dev if minOut is not contrained, the convert will succeed,
+     * @dev if minOut is not constrained, the convert will succeed,
      * but only to the amount of beans that can be converted to the peg.
      */
     function test_convertBeanToWell_beyondPeg(uint256 beansRemovedFromWell) public {
@@ -723,7 +723,7 @@ contract ConvertTest is TestHelper {
         // set deltaB negative
         setDeltaBforWell(int256(-10000e6), BEAN_ETH_WELL, WETH);
 
-        // decreasing demand for convert behaviour.
+        // decreasing demand for convert behavior.
 
         // verify convert factor does not change < 12 seasons below peg.
         // verify convert factor increases after.
@@ -797,7 +797,7 @@ contract ConvertTest is TestHelper {
         for (uint256 i = 1; i < 111; i++) {
             // simulate converting 100 bdv.
             if (i < 101) {
-                // increasing demand for convert behaviour.
+                // increasing demand for convert behavior.
                 baseBdvConverted = (baseBdvConverted * 106) / 100;
                 warpToNextSeasonAndUpdateOracles();
                 bs.mockUpdateBdvConverted(baseBdvConverted);
@@ -812,7 +812,7 @@ contract ConvertTest is TestHelper {
                     (LibGaugeHelpers.ConvertBonusGaugeValue)
                 );
 
-                // verify behaviour:
+                // verify behavior:
                 assertEq(
                     gv.convertCapacityFactor,
                     gd.minCapacityFactor + (0.004e18 * i),
@@ -837,7 +837,7 @@ contract ConvertTest is TestHelper {
 
                 // TODO: measure stalk gained
             } else {
-                // steady demand for convert behaviour.
+                // steady demand for convert behavior.
                 warpToNextSeasonAndUpdateOracles();
                 bs.mockUpdateBdvConverted(baseBdvConverted);
                 vm.roll(block.number + 1800);
@@ -851,7 +851,7 @@ contract ConvertTest is TestHelper {
                     (LibGaugeHelpers.ConvertBonusGaugeValue)
                 );
 
-                // verify behaviour:
+                // verify behavior:
                 assertEq(
                     gv.convertCapacityFactor,
                     gd.maxCapacityFactor,
@@ -877,7 +877,7 @@ contract ConvertTest is TestHelper {
         }
     }
 
-    // verfies the convert capacity increases over the course of a season.
+    // verifies the convert capacity increases over the course of a season.
     function test_convertUpBonus_time() public {
         // set deltaB negative
         setDeltaBforWell(int256(-10000e6), BEAN_ETH_WELL, WETH);
@@ -1182,8 +1182,8 @@ contract ConvertTest is TestHelper {
 
         // stalk bonus gauge data
 
-        // update bdv capacity to allow for more bdv to get the bonus
-        bs.mockUpdateBonusBdvCapacity(type(uint256).max);
+        // update bdv capacity such that any convert will get the bonus
+        bs.mockUpdateBonusBdvCapacity(type(uint128).max);
 
         LibGaugeHelpers.ConvertBonusGaugeData memory gdBefore = abi.decode(
             bs.getGaugeData(GaugeId.CONVERT_UP_BONUS),
@@ -1311,7 +1311,7 @@ contract ConvertTest is TestHelper {
     //////////// LAMBDA/LAMBDA ////////////
 
     /**
-     * @notice lamda_lamda convert increases BDV.
+     * @notice lambda_lambda convert increases BDV.
      */
     function test_lambdaLambda_increaseBDV(uint256 deltaB) public {
         uint256 lpMinted = multipleWellDepositSetup();
@@ -1327,7 +1327,7 @@ contract ConvertTest is TestHelper {
 
         uint256 amtToConvert = lpMinted / 2;
 
-        // create lamda_lamda encoding.
+        // create lambda_lambda encoding.
         bytes memory convertData = convertEncoder(
             LibConvertData.ConvertKind.LAMBDA_LAMBDA,
             well,
@@ -1357,7 +1357,7 @@ contract ConvertTest is TestHelper {
     }
 
     /**
-     * @notice lamda_lamda convert does not decrease BDV.
+     * @notice lambda_lambda convert does not decrease BDV.
      */
     function test_lamdaLamda_decreaseBDV(uint256 deltaB) public {
         uint256 lpMinted = multipleWellDepositSetup();
@@ -1372,7 +1372,7 @@ contract ConvertTest is TestHelper {
         IWell(well).shift(IERC20(bean), 0, farmers[0]);
         uint256 amtToConvert = lpMinted / 2;
 
-        // create lamda_lamda encoding.
+        // create lambda_lambda encoding.
         bytes memory convertData = convertEncoder(
             LibConvertData.ConvertKind.LAMBDA_LAMBDA,
             well,
@@ -1399,13 +1399,13 @@ contract ConvertTest is TestHelper {
     }
 
     /**
-     * @notice lamda_lamda convert combines deposits.
+     * @notice lambda_lambda convert combines deposits.
      */
-    function test_lamdaLamda_combineDeposits(uint256 lpCombined) public {
+    function test_lambdaLambda_combineDeposits(uint256 lpCombined) public {
         uint256 lpMinted = multipleWellDepositSetup();
         lpCombined = bound(lpCombined, 2, lpMinted);
 
-        // create lamda_lamda encoding.
+        // create lambda_lambda encoding.
         bytes memory convertData = convertEncoder(
             LibConvertData.ConvertKind.LAMBDA_LAMBDA,
             well,


### PR DESCRIPTION
Currently, the convert bonus capacity (the amount of PDV that can be converted and get a bonus) is issued at the start of the `gm` call. This creates an incentive to convert immediately after the `gm` call. When a large amount of PDV is converted at a given instance, the farmer(s) may realize large losses due to slippage, and is easily sandwichable. An ideal scenario for both the protocol and the user(s) would be to spread the convert over the course of the season. 

This PR ramps the convert capacity over time, such that users are able to split their converts over time without forfeiting a convert bonus. The current parameters are: 
- An initial capacity of 10% of the maximum convert capacity, at the start of the season.
- A linear ramp to 100% of the maximum convert capacity once 75% of the season has elapsed (45 minutes in).

A linear ramp to 100% at a certain point in the season was chosen, as Pinto wants the distribution of converts to be normal throughout the season. Ideally, Pinto would have the capacity ramp up over the course of the entire season, but due to the cost of execution to perform continuous orders, a shorter ramp up period is needed to allow farmers to use the entire convert capacity.
