### PR TITLE
add ability for protocol to filter deposits to get a bonus

### DIFF
--- a/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
+++ b/contracts/beanstalk/facets/silo/ConvertGettersFacet.sol
@@ -232,13 +232,15 @@ contract ConvertGettersFacet {
     /**
      * @notice Returns the amount of grown stalk gained from the convert up bonus.
      * @dev Users start receiving a bonus for converting up when bean is below peg for at least 12 seasons.
-     * @param bdvToConvert The resulting bdv of the convert.
+     * @param stems The stems of the deposits that are converting.
+     * @param bdvs The bdvs of the deposits that are converting.
      * @return bdvCapacityUsed The amount of bdv that got the bonus.
      * @return grownStalkGained The amount of grown stalk gained from the bonus.
      */
     function stalkBonus(
-        uint256 bdvToConvert
+        int96[] memory stems,
+        uint256[] memory bdvs
     ) external view returns (uint256 bdvCapacityUsed, uint256 grownStalkGained) {
-        return LibConvert.stalkBonus(bdvToConvert);
+        return LibConvert.stalkBonus(stems, bdvs);
     }
 }

--- a/contracts/mocks/mockFacets/MockConvertFacet.sol
+++ b/contracts/mocks/mockFacets/MockConvertFacet.sol
@@ -27,7 +27,7 @@ contract MockConvertFacet is ConvertFacet {
     ) external {
         LibSilo._mow(msg.sender, token);
         // if (account == address(0)) account = msg.sender;
-        (uint256 stalkRemoved, uint256 bdvRemoved, ) = LibConvert._withdrawTokens(
+        (uint256 stalkRemoved, uint256 bdvRemoved, , ) = LibConvert._withdrawTokens(
             token,
             stems,
             amounts,


### PR DESCRIPTION
Currently, the convert bonus is designed such that all deposits are eligible for the bonus. This creates an issue where someone can withdraw, redeposit, and convert, gaining a bonus. 

In practice, the bonus now becomes a grown stalk floor for new deposits and diminishes the efficacy of the stalk system. 

This PR adds an function that allows the protocol to filter converted deposits to give them a bdv. The criteria of determining the bonus is TBD. 