### PR TITLE
Pi 10/cultivation factor v1.1

### DIFF
--- a/abi/Beanstalk.json
+++ b/abi/Beanstalk.json
@@ -2029,6 +2029,25 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum GaugeId",
+        "name": "gaugeId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "UpdatedGaugeData",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "activeField",
     "outputs": [
@@ -8247,25 +8266,6 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "UpdatedGaugeData",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "enum GaugeId",
-        "name": "gaugeId",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
         "name": "value",
         "type": "bytes"
       }
@@ -9322,9 +9322,9 @@
             "type": "uint32"
           },
           {
-            "internalType": "uint32",
+            "internalType": "uint64",
             "name": "temp",
-            "type": "uint32"
+            "type": "uint64"
           },
           {
             "internalType": "uint16",
@@ -9332,9 +9332,9 @@
             "type": "uint16"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint128",
             "name": "morningControl",
-            "type": "uint256"
+            "type": "uint128"
           },
           {
             "internalType": "bytes32[3]",

--- a/abi/MockBeanstalk.json
+++ b/abi/MockBeanstalk.json
@@ -2029,6 +2029,25 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum GaugeId",
+        "name": "gaugeId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "UpdatedGaugeData",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "activeField",
     "outputs": [
@@ -8247,25 +8266,6 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "UpdatedGaugeData",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "enum GaugeId",
-        "name": "gaugeId",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
         "name": "value",
         "type": "bytes"
       }
@@ -9322,9 +9322,9 @@
             "type": "uint32"
           },
           {
-            "internalType": "uint32",
+            "internalType": "uint64",
             "name": "temp",
-            "type": "uint32"
+            "type": "uint64"
           },
           {
             "internalType": "uint16",
@@ -9332,9 +9332,9 @@
             "type": "uint16"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint128",
             "name": "morningControl",
-            "type": "uint256"
+            "type": "uint128"
           },
           {
             "internalType": "bytes32[3]",
@@ -11062,12 +11062,30 @@
   {
     "inputs": [
       {
-        "internalType": "uint32",
+        "internalType": "uint64",
         "name": "t",
-        "type": "uint32"
+        "type": "uint64"
       }
     ],
     "name": "setMaxTemp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "prevSeasonTemp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "soldOutTemp",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPrevSeasonAndSoldOutTemp",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -12168,9 +12186,9 @@
   {
     "inputs": [
       {
-        "internalType": "uint32",
+        "internalType": "uint64",
         "name": "number",
-        "type": "uint32"
+        "type": "uint64"
       }
     ],
     "name": "setMaxTempE",

--- a/contracts/beanstalk/facets/sun/GaugeFacet.sol
+++ b/contracts/beanstalk/facets/sun/GaugeFacet.sol
@@ -100,7 +100,7 @@ contract GaugeFacet is GaugeDefault, ReentrancyGuard {
         // if soil was almost sold out or sold out, and demand for soil is increasing,
         //  set cultivationTemp to the previous season temperature.
         if (
-            soilAlmostSoldOut &&
+            (soilAlmostSoldOut || soilSoldOut) &&
             bs.deltaPodDemand.value > s.sys.evaluationParameters.deltaPodDemandUpperBound
         ) {
             cultivationTemp = prevSeasonTemp;

--- a/contracts/beanstalk/init/InitPI10.sol
+++ b/contracts/beanstalk/init/InitPI10.sol
@@ -41,12 +41,12 @@ contract InitPI10 {
         LibGaugeHelpers.updateGaugeValue(GaugeId.CONVERT_UP_BONUS, abi.encode(gv));
     }
 
-    function initMaxGaugePoints(uint256 maxGaugePoints) internal {
+    function initMaxGaugePoints(uint128 maxGaugePoints) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // Set the max total gauge points to MAX_TOTAL_GAUGE_POINTS
-        s.sys.seedGauge.maxTotalGaugePoints = MAX_TOTAL_GAUGE_POINTS;
-        emit LibGauge.UpdateMaxTotalGaugePoints(MAX_TOTAL_GAUGE_POINTS);
+        s.sys.seedGauge.maxTotalGaugePoints = maxGaugePoints;
+        emit LibGauge.UpdateMaxTotalGaugePoints(maxGaugePoints);
 
         address[] memory whitelistedLpTokens = LibWhitelistedTokens.getWhitelistedLpTokens();
 

--- a/contracts/beanstalk/init/InitPI10.sol
+++ b/contracts/beanstalk/init/InitPI10.sol
@@ -20,7 +20,7 @@ contract InitPI10 {
     uint128 constant MAX_TOTAL_GAUGE_POINTS = 10000e18;
     uint32 constant PEG_CROSS_SEASON = 2558;
     uint16 constant MORNING_DURATION = 600;
-    uint256 constant MORNING_CONTROL = uint256(1e18) / 240;
+    uint128 constant MORNING_CONTROL = uint128(1e18) / 240;
 
     function init(
         uint256 bonusStalkPerBdv,

--- a/contracts/beanstalk/init/InitializeDiamond.sol
+++ b/contracts/beanstalk/init/InitializeDiamond.sol
@@ -189,7 +189,7 @@ contract InitializeDiamond {
         s.sys.weather.thisSowTime = type(uint32).max;
         s.sys.weather.lastSowTime = type(uint32).max;
         s.sys.weather.morningDuration = 600; // 10 minutes
-        s.sys.weather.morningControl = uint256(1e18) / 240; // 1 / 240 = 0.004166666667
+        s.sys.weather.morningControl = uint128(1e18) / 240; // 1 / 240 = 0.004166666667
         s.sys.extEvaluationParameters.minSoilIssuance = MIN_SOIL_ISSUANCE;
     }
 

--- a/contracts/beanstalk/storage/System.sol
+++ b/contracts/beanstalk/storage/System.sol
@@ -166,9 +166,9 @@ struct Weather {
     uint128 lastDeltaSoil; // ───┐ 16 (16)
     uint32 lastSowTime; //       │ 4  (20)
     uint32 thisSowTime; //       │ 4  (24)
-    uint32 temp; //              │ 4  (28)
-    uint16 morningDuration; // ──┘ 2  (30/32)
-    uint256 morningControl;
+    uint64 temp; // ─────────────┘ 8  (32)
+    uint128 morningDuration; //  ───┐ 16 (16)
+    uint128 morningControl; // ─────┘ 16 (32)
     bytes32[3] _buffer;
 }
 

--- a/contracts/beanstalk/storage/System.sol
+++ b/contracts/beanstalk/storage/System.sol
@@ -167,8 +167,8 @@ struct Weather {
     uint32 lastSowTime; //       │ 4  (20)
     uint32 thisSowTime; //       │ 4  (24)
     uint64 temp; // ─────────────┘ 8  (32)
-    uint128 morningDuration; //  ───┐ 16 (16)
-    uint128 morningControl; // ─────┘ 16 (32)
+    uint16 morningDuration; //  ────┐ 2  (2)
+    uint128 morningControl; // ─────┘ 16 (18)
     bytes32[3] _buffer;
 }
 

--- a/contracts/interfaces/IMockFBeanstalk.sol
+++ b/contracts/interfaces/IMockFBeanstalk.sol
@@ -1597,9 +1597,9 @@ interface IMockFBeanstalk {
 
     function setLastSowTimeE(uint32 number) external;
 
-    function setMaxTemp(uint32 t) external;
+    function setMaxTemp(uint64 t) external;
 
-    function setMaxTempE(uint32 number) external;
+    function setMaxTempE(uint64 number) external;
 
     function setNextSowTimeE(uint32 _time) external;
 

--- a/contracts/interfaces/IMockFBeanstalk.sol
+++ b/contracts/interfaces/IMockFBeanstalk.sol
@@ -1921,4 +1921,6 @@ interface IMockFBeanstalk {
         returns (uint256 bonusStalkPerBdv, uint256 remainingCapacity);
 
     function mockUpdateStalkPerBdvBonus(uint256 newStalkPerBdvBonus) external;
+
+    function setPrevSeasonAndSoldOutTemp(uint256 prevSeasonTemp, uint256 soldOutTemp) external;
 }

--- a/contracts/libraries/LibDibbler.sol
+++ b/contracts/libraries/LibDibbler.sol
@@ -16,6 +16,7 @@ import {LibTransfer} from "contracts/libraries/Token/LibTransfer.sol";
 import {LibTractor} from "contracts/libraries/LibTractor.sol";
 import {IBean} from "contracts/interfaces/IBean.sol";
 import {C} from "contracts/C.sol";
+import {LibGaugeHelpers} from "./LibGaugeHelpers.sol";
 
 /**
  * @title LibDibbler
@@ -200,6 +201,9 @@ library LibDibbler {
         }
 
         s.sys.weather.thisSowTime = uint32(block.timestamp.sub(s.sys.season.timestamp));
+
+        // store the temperature in which soil sold out, in the cultivation factor gauge.
+        LibGaugeHelpers.updateSoldOutTemperature();
     }
 
     /**

--- a/contracts/libraries/LibGaugeHelpers.sol
+++ b/contracts/libraries/LibGaugeHelpers.sol
@@ -223,6 +223,45 @@ library LibGaugeHelpers {
         return s.sys.gaugeData.gauges[gaugeId].data;
     }
 
+    /// GAUGE SPECIFIC HELPERS ///
+
+    function updateSoldOutTemperature() internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        (
+            uint256 minDeltaCf,
+            uint256 maxDeltaCf,
+            uint256 minCf,
+            uint256 maxCf,
+            ,
+            uint256 prevSeasonTemp
+        ) = abi.decode(
+                getGaugeData(GaugeId.CULTIVATION_FACTOR),
+                (uint256, uint256, uint256, uint256, uint256, uint256)
+            );
+        updateGaugeData(
+            GaugeId.CULTIVATION_FACTOR,
+            abi.encode(minDeltaCf, maxDeltaCf, minCf, maxCf, s.sys.weather.temp, prevSeasonTemp)
+        );
+    }
+
+    function updatePrevSeasonTemp(uint256 temperature) internal {
+        (
+            uint256 minDeltaCf,
+            uint256 maxDeltaCf,
+            uint256 minCf,
+            uint256 maxCf,
+            uint256 soldOutTemp,
+
+        ) = abi.decode(
+                getGaugeData(GaugeId.CULTIVATION_FACTOR),
+                (uint256, uint256, uint256, uint256, uint256, uint256)
+            );
+        updateGaugeData(
+            GaugeId.CULTIVATION_FACTOR,
+            abi.encode(minDeltaCf, maxDeltaCf, minCf, maxCf, soldOutTemp, temperature)
+        );
+    }
+
     /// GAUGE BLOCKS ///
 
     /**

--- a/contracts/libraries/LibGaugeHelpers.sol
+++ b/contracts/libraries/LibGaugeHelpers.sol
@@ -225,7 +225,7 @@ library LibGaugeHelpers {
 
     /// GAUGE SPECIFIC HELPERS ///
 
-    function updateSoldOutTemperature() internal {
+    function updateSoilSellingOutTemperature() internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         (
             uint256 minDeltaCf,

--- a/contracts/libraries/LibInitGauges.sol
+++ b/contracts/libraries/LibInitGauges.sol
@@ -53,7 +53,9 @@ library LibInitGauges {
                 MIN_DELTA_CULTIVATION_FACTOR,
                 MAX_DELTA_CULTIVATION_FACTOR,
                 MIN_CULTIVATION_FACTOR,
-                MAX_CULTIVATION_FACTOR
+                MAX_CULTIVATION_FACTOR,
+                uint256(0), // sold out temperature
+                uint256(0) // previous season temperature
             )
         );
         LibGaugeHelpers.addGauge(GaugeId.CULTIVATION_FACTOR, cultivationFactorGauge);

--- a/contracts/libraries/LibInitGauges.sol
+++ b/contracts/libraries/LibInitGauges.sol
@@ -54,7 +54,7 @@ library LibInitGauges {
                 MAX_DELTA_CULTIVATION_FACTOR,
                 MIN_CULTIVATION_FACTOR,
                 MAX_CULTIVATION_FACTOR,
-                uint256(0), // sold out temperature
+                uint256(0), // cultivation temperature
                 uint256(0) // previous season temperature
             )
         );

--- a/contracts/libraries/Season/LibWeather.sol
+++ b/contracts/libraries/Season/LibWeather.sol
@@ -11,6 +11,8 @@ import {LibRedundantMath256} from "contracts/libraries/Math/LibRedundantMath256.
 import {LibRedundantMathSigned256} from "contracts/libraries/Math/LibRedundantMathSigned256.sol";
 import {LibEvaluate} from "contracts/libraries/LibEvaluate.sol";
 import {LibCases} from "contracts/libraries/LibCases.sol";
+import {LibGaugeHelpers} from "contracts/libraries/LibGaugeHelpers.sol";
+
 /**
  * @title LibWeather
  * @notice Library for managing Weather state in Beanstalk, including Temperature and Grown Stalk to LP ratios.
@@ -101,6 +103,8 @@ library LibWeather {
     function updateTemperature(int32 bT, uint256 caseId) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         uint256 t = s.sys.weather.temp;
+        // update the previous season temperature in the cultivation factor gauge.
+        LibGaugeHelpers.updatePrevSeasonTemp(t);
         if (bT < 0) {
             if (t <= uint256(int256(-bT))) {
                 // if temp is to be decreased and the change is greater than the current temp,

--- a/contracts/libraries/Season/LibWeather.sol
+++ b/contracts/libraries/Season/LibWeather.sol
@@ -111,10 +111,10 @@ library LibWeather {
                 bT = 1e6 - int32(int256(t));
                 s.sys.weather.temp = 1e6;
             } else {
-                s.sys.weather.temp = uint32(t - uint256(int256(-bT)));
+                s.sys.weather.temp = uint64(t - uint256(int256(-bT)));
             }
         } else {
-            s.sys.weather.temp = uint32(t + uint256(int256(bT)));
+            s.sys.weather.temp = uint64(t + uint256(int256(bT)));
         }
 
         emit TemperatureChange(s.sys.season.current, caseId, bT, s.sys.activeField);

--- a/contracts/mocks/mockFacets/MockFieldFacet.sol
+++ b/contracts/mocks/mockFacets/MockFieldFacet.sol
@@ -213,4 +213,19 @@ contract MockFieldFacet is FieldFacet {
     function setCultivationFactor(uint256 cultivationFactor) external {
         s.sys.gaugeData.gauges[GaugeId.CULTIVATION_FACTOR].value = abi.encode(cultivationFactor);
     }
+
+    function setPrevSeasonAndSoldOutTemp(uint256 prevSeasonTemp, uint256 soldOutTemp) external {
+        (uint256 minDeltaCf, uint256 maxDeltaCf, uint256 minCf, uint256 maxCf, , ) = abi.decode(
+            s.sys.gaugeData.gauges[GaugeId.CULTIVATION_FACTOR].data,
+            (uint256, uint256, uint256, uint256, uint256, uint256)
+        );
+        s.sys.gaugeData.gauges[GaugeId.CULTIVATION_FACTOR].data = abi.encode(
+            minDeltaCf,
+            maxDeltaCf,
+            minCf,
+            maxCf,
+            soldOutTemp,
+            prevSeasonTemp
+        );
+    }
 }

--- a/contracts/mocks/mockFacets/MockFieldFacet.sol
+++ b/contracts/mocks/mockFacets/MockFieldFacet.sol
@@ -206,7 +206,7 @@ contract MockFieldFacet is FieldFacet {
             );
     }
 
-    function setMaxTemp(uint32 t) external {
+    function setMaxTemp(uint64 t) external {
         s.sys.weather.temp = t;
     }
 

--- a/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -277,7 +277,7 @@ contract MockSeasonFacet is SeasonFacet {
         s.sys.season.sunriseBlock = uint64(block.number);
     }
 
-    function setMaxTempE(uint32 number) public {
+    function setMaxTempE(uint64 number) public {
         s.sys.weather.temp = number;
     }
 

--- a/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -64,7 +64,7 @@ contract MockSeasonFacet is SeasonFacet {
     }
 
     function setYieldE(uint256 t) public {
-        s.sys.weather.temp = uint32(t);
+        s.sys.weather.temp = uint64(t);
     }
 
     function setTotalStalkE(uint256 amount) public {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -897,7 +897,7 @@ task(
     object: !mock,
     verbose: true,
     account: owner,
-    initArgs: [10000000000],
+    initArgs: [10000000000, 749e6, 749e6],
     initFacetName: "InitPI10"
   });
 });

--- a/test/foundry/field/Field.t.sol
+++ b/test/foundry/field/Field.t.sol
@@ -287,13 +287,42 @@ contract FieldTest is TestHelper {
     }
 
     /**
-     * Checking next sow time, with more than 1 soil available *after* sowing.
-     * @dev Does not set `thisSowTime` if `s.sys.soil` is above the dynamic threshold.
+     * Checking next sow time, with more than 1 soil above the dynamic almost sold out threshold.
+     * @dev Verifies that `thisSowTime` is at the max value
      */
-    function testComplexDPDMoreThan1Soil(uint256 initialSoil, uint256 farmerSown) public {
+    function testComplexDPDMoreThan1SoilAlmostSoldOut(
+        uint256 initialSoil,
+        uint256 farmerSown
+    ) public {
         initialSoil = bound(initialSoil, 2e6, type(uint128).max);
         // calculate threshold
         uint256 soilSoldOutThreshold = (initialSoil < 100e6) ? 0 : (initialSoil * 0.01e6) / 1e6;
+        uint256 almostSoldOutThreshold = (((initialSoil - soilSoldOutThreshold) * 0.20e6) / 1e6) +
+            soilSoldOutThreshold;
+        // ensure at least `soilSoldOutThreshold + 1` remains after sowing
+        farmerSown = bound(farmerSown, 1, initialSoil - (almostSoldOutThreshold + 1));
+        // set initial soil
+        bs.setSoilE(initialSoil);
+        bean.mint(farmers[0], farmerSown);
+        uint256 beans = bean.balanceOf(farmers[0]);
+        // Simulate sowing
+        vm.prank(farmers[0]);
+        field.sow(beans, 0, LibTransfer.From.EXTERNAL);
+        IMockFBeanstalk.Weather memory w = bs.weather();
+        // Verify that `thisSowTime` was set to the max value minus 1. (almost sold out)
+        // otherwise, soil is not sold out
+        assertEq(uint256(w.thisSowTime), type(uint32).max);
+    }
+
+    /**
+     * Checking next sow time, with more than at least 1 soil + soldOut threshold.
+     */
+    function testComplexDPDMoreThan1SoilSoldOut(uint256 initialSoil, uint256 farmerSown) public {
+        initialSoil = bound(initialSoil, 2e6, type(uint128).max);
+        // calculate threshold
+        uint256 soilSoldOutThreshold = (initialSoil < 100e6) ? 0 : (initialSoil * 0.01e6) / 1e6;
+        uint256 almostSoldOutThreshold = (((initialSoil - soilSoldOutThreshold) * 0.20e6) / 1e6) +
+            soilSoldOutThreshold;
         // ensure at least `soilSoldOutThreshold + 1` remains after sowing
         farmerSown = bound(farmerSown, 1, initialSoil - (soilSoldOutThreshold + 1));
         // set initial soil
@@ -304,8 +333,14 @@ contract FieldTest is TestHelper {
         vm.prank(farmers[0]);
         field.sow(beans, 0, LibTransfer.From.EXTERNAL);
         IMockFBeanstalk.Weather memory w = bs.weather();
-        // Verify that `thisSowTime` was not set
-        assertEq(uint256(w.thisSowTime), type(uint32).max);
+
+        // if user sowed some amount such that soil is almost sold out,
+        if (initialSoil - almostSoldOutThreshold <= farmerSown) {
+            assertEq(uint256(w.thisSowTime), type(uint32).max - 1);
+        } else {
+            // Verify that `thisSowTime` was not set
+            assertEq(uint256(w.thisSowTime), type(uint32).max);
+        }
     }
 
     function _minPods(uint256 sowAmount) internal view returns (uint256) {
@@ -405,7 +440,7 @@ contract FieldTest is TestHelper {
     }
 
     /**
-     * @notice verfies that a farmer's plot index is updated correctly.
+     * @notice verifies that a farmer's plot index is updated correctly.
      * @dev partial harvests and transfers are tested here. full harvests/transfers can be seen in `test_plotIndexMultiple`.
      */
     function test_plotIndexList(uint256 sowAmount, uint256 portion) public {
@@ -469,7 +504,7 @@ contract FieldTest is TestHelper {
     /**
      * @notice performs a series of actions to verify sows multiple times and verifies that the plot index is updated correctly.
      * 1. sowing properly increments the plot index.
-     * 2. transfering a plot properly decrements the senders' plot index,
+     * 2. transferring a plot properly decrements the senders' plot index,
      * and increments the recipients' plot index.
      * 3. harvesting a plot properly decrements the senders' plot index.
      */

--- a/test/foundry/sun/Cases.t.sol
+++ b/test/foundry/sun/Cases.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.0 <0.9.0;
 pragma abicoder v2;
 
 import {TestHelper, LibTransfer, IWell, IERC20, IMockFBeanstalk} from "test/foundry/utils/TestHelper.sol";
+import {GaugeId} from "contracts/beanstalk/storage/System.sol";
 import {C} from "contracts/C.sol";
 import "forge-std/console.sol";
 
@@ -90,9 +91,17 @@ contract CasesTest is TestHelper {
         vm.expectEmit(true, true, false, false);
         emit BeanToMaxLpGpPerBdvRatioChange(1, caseId, 0);
 
+        uint256 prevTemp = bs.maxTemperature();
         (uint256 updatedCaseId, ) = season.mockcalcCaseIdAndHandleRain(deltaB);
         require(updatedCaseId == caseId, "CaseId did not match");
         (, int32 bT, , int80 bL) = bs.getChangeFromCaseId(caseId);
+
+        // verify that the prevSeasonTemp is set.
+        (, , , , , uint256 prevSeasonTemp) = abi.decode(
+            bs.getGaugeData(GaugeId.CULTIVATION_FACTOR),
+            (uint256, uint256, uint256, uint256, uint256, uint256)
+        );
+        assertEq(prevSeasonTemp, prevTemp, "prevSeasonTemp was not properly set");
 
         // CASE INVARIANTS
         // if deltaB > 0: temperature should never increase. bean2MaxLpGpRatio should never increase.

--- a/test/foundry/sun/Sun.t.sol
+++ b/test/foundry/sun/Sun.t.sol
@@ -878,6 +878,28 @@ contract SunTest is TestHelper {
             1.111111e6,
             "deltaCultivationFactor should be ~1.111111% with pod rate at midpoint, $0.72 price, and soil not sold out"
         );
+
+        // Case 7: Soil not sold out, sold out temp is higher than prevSeasonTemp,  should not change cultivationFactor
+        season.setLastSowTimeE(type(uint32).max); // Set soil as not sold out
+        bs.setPrevSeasonAndSoldOutTemp(100e6, 101e6);
+        deltaCultivationFactor = season.calculateCultivationFactorDeltaE(testState);
+        assertEq(
+            deltaCultivationFactor,
+            0,
+            "deltaCultivationFactor should be 0 when sold out temp is higher than prevSeasonTemp"
+        );
+
+        // Case 7: Soil sold out, sold out temp is higher than prevSeasonTemp,  should change cultivationFactor
+        season.setLastSowTimeE(1); // Set soil as sold out
+        for (uint256 i = 0; i < 3; i++) {
+            bs.setPrevSeasonAndSoldOutTemp(100e6, 99e6 + (i * 1e6)); // 99e6, 100e6, 101e6
+            deltaCultivationFactor = season.calculateCultivationFactorDeltaE(testState);
+            assertEq(
+                deltaCultivationFactor,
+                0.9e6,
+                "deltaCultivationFactor should change when soil is sold out, independent of prevSeasonTemp"
+            );
+        }
     }
 
     function test_calculateCultivationFactorDelta() public {


### PR DESCRIPTION
Currently, the Cultivation Factor increases/decreases only as a function of soil selling out. This creates an inefficiency in the cultivation factor ramping up in cases where the market only has demand for soil at a set temperature.

Ideally, the protocol should decrease its soil issuance only when it is certain that there is a lack of demand of soil at a set temperature (rather than only accounting for soil demand). 

This PR updates the following: 
- 1) Introduce a threshold in which soil is *selling out* (not sold out). This is currently set at 80% of the amount of soil it takes to sell out. 
- 2) Pinto now logs the temperature which demand for soil was increasing, AND that soil was selling out. 
- 3) upon a `gm` call the cultivation factor now increases, decreases, or stays the same as follows: 
    - If soil has sold out, CF increases. 
    - else if soil was selling out (i.e either selling out, or almost selling out), CF  stays the same. 
    - else if demand for soil is decreasing, AND last seasons temperature is lower than the cultivation temperature, CF stays the same.
    - else, CF decreases.

This would change the behavior of the Cultivation Factor to look like the line in red, based on current conditions (assuming the market does not change their actions based on this change):
![image](https://github.com/user-attachments/assets/a63be7e1-a94b-4c5a-9b41-2001fbe47b35)
