### PR TITLE
fix: add missing facetAddresses Hardhat task

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1722,6 +1722,86 @@ task("ecosystemABI", "Generates ABI files for ecosystem contracts").setAction(as
   }
 });
 
+task("facetAddresses", "Displays current addresses of specified facets on Base mainnet")
+  .addParam("facets", "Comma-separated list of facet names to look up")
+  .addFlag("urls", "Show BaseScan URLs for the facets")
+  .setAction(async (taskArgs) => {
+    const BASESCAN_API_KEY = process.env.ETHERSCAN_KEY_BASE;
+    if (!BASESCAN_API_KEY) {
+      console.error("❌ Please set ETHERSCAN_KEY_BASE in your environment variables");
+      return;
+    }
+
+    const diamond = await ethers.getContractAt("IDiamondLoupe", L2_PINTO);
+
+    // Get all facets from the diamond
+    const allFacets = await diamond.facets();
+
+    // Get the requested facet names
+    const requestedFacets = taskArgs.facets.split(",").map((f) => f.trim());
+
+    console.log("\n🔍 Looking up facet addresses on Base mainnet...");
+    console.log("-----------------------------------");
+
+    // Create a map of addresses to their contract names
+    const addressToName = new Map();
+
+    // Fetch contract names from BaseScan for each unique address
+    const uniqueAddresses = [...new Set(allFacets.map((f) => f.facetAddress))];
+
+    for (const address of uniqueAddresses) {
+      try {
+        let data;
+        let attempts = 0;
+        const maxAttempts = 3;
+
+        do {
+          const response = await fetch(
+            `https://api.basescan.org/api?module=contract&action=getsourcecode&address=${address}&apikey=${BASESCAN_API_KEY}`
+          );
+          data = await response.json();
+          attempts++;
+
+          if (data.status === "1" && data.result[0]) {
+            const contractName = data.result[0].ContractName;
+            addressToName.set(address, contractName);
+            break;
+          }
+
+          // Wait 1 second before retrying
+          if (data.status === "0" && attempts < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        } while (data.status === "0" && attempts < maxAttempts);
+      } catch (e) {
+        console.log(`⚠️  Error fetching contract name for ${address}: ${e.message}`);
+      }
+    }
+
+    // For each requested facet, find its address
+    for (const facetName of requestedFacets) {
+      let found = false;
+
+      for (const facet of allFacets) {
+        const contractName = addressToName.get(facet.facetAddress);
+        if (contractName && contractName.toLowerCase() === facetName.toLowerCase()) {
+          console.log(`📦 ${facetName}: ${facet.facetAddress}`);
+          if (taskArgs.urls) {
+            console.log(`   🔗 https://basescan.org/address/${facet.facetAddress}`);
+          }
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        console.log(`❌ ${facetName}: Not found on diamond`);
+      }
+    }
+
+    console.log("-----------------------------------");
+  });
+
 //////////////////////// CONFIGURATION ////////////////////////
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Adds the missing `facetAddresses` Hardhat task that was causing GitHub Actions facet analyzer workflow to fail
- Enables `@claude analyze facets` functionality to work properly
- Task displays current facet addresses on Base mainnet with optional BaseScan URLs

## Technical Details
- Extracted task definition from `facet-names-to-addys-task` branch
- Added task between `ecosystemABI` task and configuration section in `hardhat.config.js`
- Task requires `ETHERSCAN_KEY_BASE` environment variable for BaseScan API access
- Supports comma-separated facet names and optional `--urls` flag for BaseScan links

## Test Plan
- [ ] Verify task appears in `npx hardhat` task list
- [ ] Test task execution with sample facet names
- [ ] Confirm GitHub Actions facet analyzer workflow no longer fails with HH303 error

## Fixes
Resolves the `HH303: Unrecognized task 'facetAddresses'` error in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)