### PR TITLE
Update reward scaling comments to reflect accurate multipliers

### DIFF
--- a/contracts/libraries/LibIncentive.sol
+++ b/contracts/libraries/LibIncentive.sol
@@ -50,7 +50,9 @@ library LibIncentive {
 
     /**
      * @dev fraxExp scales up the bean reward based on the seconds late.
-     * the formula is beans * (1.01)^(seconds late).
+     * The formula is `beans * (1.01)^(seconds late)`.
+     * While the underlying compounding factor is 1.01 per second, the function applies
+     * pre-calculated multipliers. For instance, for up to 2 seconds late, it uses 1.0201.
      */
     function fracExp(
         uint256 beans,


### PR DESCRIPTION
This PR updates the comments in SeasonFacet.sol to accurately reflect the reward scaling factor used in the code. Previously, comments indicated a 1.01 scaler, while the implementation uses pre-calculated values where the effective scaler for the first two seconds is 1.0201 (1.01^2). The JSDoc comment has been updated to include new changes.