### PR TITLE
Refactor Reward Scaling Logic and Update Comments

### DIFF
--- a/contracts/libraries/LibIncentive.sol
+++ b/contracts/libraries/LibIncentive.sol
@@ -50,7 +50,9 @@ library LibIncentive {
 
     /**
      * @dev fraxExp scales up the bean reward based on the seconds late.
-     * the formula is beans * (1.01)^(seconds late).
+     * The formula is `beans * (1.01)^(seconds late)`.
+     * While the underlying compounding factor is 1.01 per second, the function applies
+     * pre-calculated multipliers. For instance, for up to 2 seconds late, it uses 1.0201.
      */
     function fracExp(
         uint256 beans,

--- a/contracts/libraries/LibIncentive.sol
+++ b/contracts/libraries/LibIncentive.sol
@@ -50,9 +50,8 @@ library LibIncentive {
 
     /**
      * @dev fraxExp scales up the bean reward based on the seconds late.
-     * The formula is `beans * (1.01)^(seconds late)`.
-     * While the underlying compounding factor is 1.01 per second, the function applies
-     * pre-calculated multipliers. For instance, for up to 2 seconds late, it uses 1.0201.
+     * This function uses an if-ladder with pre-calculated scaling factors to determine
+     * the reward based on `secondsLate`. The underlying compounding factor is 1.01 per second.
      */
     function fracExp(
         uint256 beans,
@@ -68,9 +67,6 @@ library LibIncentive {
         // would rather incentivize slightly more to call sunrise earlier than to incentivize slightly less for a later sunrise.
         // repeat until 300 seconds:
         if (secondsLate <= 30) {
-            if (secondsLate == 0) {
-                return _scaleReward(beans, 1_000_000);
-            }
             if (secondsLate <= 2) {
                 return _scaleReward(beans, 1_020_100);
             }


### PR DESCRIPTION
This pull request implements two key improvements to the LibIncentive library:

1 - Eliminates Redundant `secondsLate == 0 Check`: The fracExp function previously contained a redundant check for `secondsLate == 0` nested within its conditional logic. This has been removed, making the if-ladder clearer. The initial `if (secondsLate == 0)` check at the top of the function now definitively handles this base case by returning the beans value unscaled, which is consistent with the effective outcome of `_scaleReward(beans, 1_000_000)` when `FRAC_EXP_PRECISION` is `1_000_000`.

2 - Updates Reward Scaling Comments for Accuracy: The comments within the determineReward and fracExp functions have been updated to accurately reflect the reward scaling factors used in the code. Previously, some comments implied a 1.01 scaler, while the implementation uses pre-calculated values where the effective scaler for the first two seconds, for example, is 1.0201 (which is 1.01^2). The JSDoc comment for fracExp has been adjusted to provide a more precise explanation of the function's behavior regarding these pre-calculated multipliers.



